### PR TITLE
fix:狩猎场选择第七章,中断没有唤起 #39

### DIFF
--- a/assets/resource/pipeline/Battle.json
+++ b/assets/resource/pipeline/Battle.json
@@ -58,8 +58,7 @@
     "recognition": "OCR",
     "action": "Click",
     "next": [
-      "Battle_CollectMapShouLie",
-      "Battle_CollectMap"
+      "Battle_CollectMapShouLie"
     ],
     "pre_wait_freezes": 1500,
     "focus": "BM.快速狩猎地图,默认位置",


### PR DESCRIPTION
Hotfix ，代码测试率100%，2次。

关于进入狩猎场复位的功能需求应等待后续重构，目前节点稳定已在临界状态，不应再修改管道。
