### PR TITLE
fix: update fileName pattern in install.yml to include architecture f…

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -244,7 +244,7 @@ jobs:
           repository: SweetSmellFox/MFAAvalonia
           latest: false
           tag: ${{ env.MFAA_TAG }}
-          fileName: "MFAAvalonia-*-${{ matrix.os == 'macos' && 'osx' || matrix.os }}*"
+          fileName: "MFAAvalonia-*-${{ matrix.os == 'macos' && 'osx' || matrix.os }}-${{ matrix.arch == 'aarch64' && 'arm64' || 'x64' }}*"
           out-file-path: "MFA"
           extract: true
 


### PR DESCRIPTION
arm64 被 x64 的覆盖了，导致最终构建的 arm64 文件都会因为架构问题，无法运行
<img width="2210" height="462" alt="Snipaste_2026-02-16_14-51-13" src="https://github.com/user-attachments/assets/537fbae7-95de-42b9-9a49-6b2c6db2143c" />

## Summary by Sourcery

Bug Fixes:
- 修复 GitHub Actions 安装工作流，使 arm64 构建产物能够被正确匹配，不再被 x64 构建产物覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix GitHub Actions install workflow so arm64 build artifacts are correctly matched and no longer overridden by x64 artifacts.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **构建优化**
  * 改进了构建流程中的工件下载机制，现在能根据目标系统体系结构自动选择对应的构建版本，提升构建的准确性和效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->