### PR TITLE
fix:NT原生PC 两处小修复(箱庭Pin3 green_mask补漏 + 快速狩猎MAX回退OCR动态)

### DIFF
--- a/assets/resource/pc/pipeline/Battle.json
+++ b/assets/resource/pc/pipeline/Battle.json
@@ -86,15 +86,6 @@
             26
         ]
     },
-    "QuickHunt_FastBattleMAXTouchHuntingGrounds": {
-        "desc": "B-1.狩猎场次数选择，点击MAX",
-        "target": [
-            485,
-            332,
-            20,
-            20
-        ]
-    },
     "QuickHunt_CollectMapAdventureRoute_Select_Glod": {
         "desc": "硬编码选择航线-金币",
         "target": [

--- a/assets/resource/pc/pipeline/Global.json
+++ b/assets/resource/pc/pipeline/Global.json
@@ -173,13 +173,14 @@
         ]
     },
     "Rec_SandBox_Pin3_Tpl": {
-        "desc": "[识别]箱庭,'pin 第3组'按钮的UI",
+        "desc": "[识别]箱庭,'pin 第3组'按钮的UI。|[PC覆盖·2026-06-30修] 与Rec_SandBox_Pin_Tpl同用pin.png,但PC覆盖只给Pin_Tpl加了green_mask漏了本节点→同按钮同模板不带green_mask仅0.459<0.7→Equip_Skill_Tap3卡死。证据:Global_ToSandBox_Enter里带green_mask的Pin_Tpl在第3pin[1198,655]打0.860。修:补green_mask:true;roi[1195,655,41,39]右缘1236裁掉第3pin(1198+40=1238)→放宽到[1188,646,56,52]罩全(x1188避开第2pin≤1187)",
         "roi": [
-            1195,
-            655,
-            41,
-            39
-        ]
+            1188,
+            646,
+            56,
+            52
+        ],
+        "green_mask": true
     },
     "Rec_Reward_Ocr": {
         "desc": "[识别]获得奖励,下方文字",


### PR DESCRIPTION
两处 PC 覆盖小修复，均 MFAAvalonia 实跑验证。基于 `feat/NT-Suport`，与 Daily PR #322 独立。

## 1. 装备/箱庭 Pin3 识别（pc/Global.json · Rec_SandBox_Pin3_Tpl）

PC 覆盖给 `Rec_SandBox_Pin_Tpl` 加了 `green_mask` 却漏了 `Rec_SandBox_Pin3_Tpl`（二者同用 `pin.png` 模板）→ 第 3 组 pin 不带 green_mask 实机仅 **0.459 < 0.7** → `Equip_Skill_Tap3` 识别不到、装备炼制日常卡死。

证据：`Global_ToSandBox_Enter` 里带 green_mask 的 `Pin_Tpl` 在同一第 3 pin [1198,655] 打 **0.860**。

修：补 `green_mask:true`；`roi[1195,655,41,39]`（右缘 1236 裁掉第 3 pin 1198+40=1238）放宽到 `[1188,646,56,52]` 罩全（x1188 避开第 2 pin ≤1187）。实跑已验证通过。

## 2. 快速狩猎 HuntingGrounds MAX 点击（pc/Battle.json · QuickHunt_FastBattleMAXTouchHuntingGrounds）

PC 覆盖给该节点硬塞了 `target[485,332]`，OCR 实测该坐标（720 空间约 495,342）正压在 **MIN** 按钮上（MAX 在约 779,339），把 base「OCR 识别 MAX/MIN 文字 → 点其命中框」的动态点击废成了 MIN 固定坐标。

`米饭分配=狩猎场x1`（override 令 expected=MIN）时碰巧不出错；但一旦切 `狩猎场MAX/双倍图x1`（expected=MAX）或走 `AdventureRouteReBack` 的 PatchNode 把 expected 改成 MAX，target 仍钉在 MIN → 永远点不到 MAX。

修：删掉整个 PC 覆盖节点，回退 base 的 OCR 动态点击（`roi[408,301,462,64]` 内的 MIN/MAX 经 OCR 实测均可识别，不受 PC 720/1080 坐标系约 2% 尺度差影响）。

## Summary by Sourcery

修复与 PC 端相关的沙盒插针选择以及快速狩猎 MAX 按钮行为的识别和交互问题。

Bug 修复：
- 通过将沙盒第三个插针的模板设置与其他插针节点对齐，修复 PC 端对该插针的识别问题，防止装备精炼流程卡住。
- 通过移除错误的固定坐标覆盖（该覆盖会始终点击 MIN），恢复 PC 端在快速狩猎中基于动态 OCR 的 MAX/MIN 按钮点击功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix PC-specific recognition and interaction issues for sandbox pin selection and fast hunting MAX button behavior.

Bug Fixes:
- Correct sandbox third pin recognition on PC by aligning its template settings with other pin nodes to prevent equipment refinement from stalling.
- Restore dynamic OCR-based clicking of the MAX/MIN button in fast hunting on PC by removing the incorrect fixed-coordinate override that always targeted MIN.

</details>