### PR TITLE
feat:快速狩猎 免费米饭清空兜底复检(#327)

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -373,6 +373,9 @@
                     "pipeline_override": {
                         "QuickHunt_AdventureRoute": {
                             "enabled": false
+                        },
+                        "QuickHunt_RiceRecheck_HuntingGrounds_Entry": {
+                            "enabled": true
                         }
                     }
                 }

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -578,6 +578,7 @@
                                 "[JumpBack]QuickHunt_OpenGui",
                                 "[JumpBack]QuickHunt_AdventureRoute",
                                 "[JumpBack]QuickHunt_HuntingGrounds",
+                                "[JumpBack]QuickHunt_RiceRecheck",
                                 "[JumpBack]QuickHunt_CrystalCave"
                             ]
                         }

--- a/assets/resource/base/pipeline/Battle.json
+++ b/assets/resource/base/pipeline/Battle.json
@@ -11,6 +11,7 @@
             "[JumpBack]QuickHunt_OpenGui",
             "[JumpBack]QuickHunt_HuntingGrounds",
             "[JumpBack]QuickHunt_AdventureRoute",
+            "[JumpBack]QuickHunt_RiceRecheck",
             "[JumpBack]QuickHunt_CrystalCave"
         ],
         "focus": "B.M 快速狩猎调度器"
@@ -1151,28 +1152,31 @@
         ],
         "only_rec": true,
         "next": [
-            "QuickHunt_RiceRecheck",
             "[Anchor]BattleMap_Reset"
         ],
         "focus": "BB.狩猎-复位模块出口\n\n 复位位置正确-成功"
     },
     "QuickHunt_RiceRecheck": {
-        "desc": "#327 免费米饭清空兜底复检:复位收口反判米饭余量,分子>0(仍有免费米饭)则回航线找当天双倍图续打(无视双倍策略,一律吃双倍);命中0/N不匹配则跳过本节点,走原收尾锚点.max_hit兜底防极端死循环",
-        "recognition": "OCR",
-        "roi": [
-            1040,
-            33,
-            111,
-            27
+        "desc": "#327 免费米饭清空兜底(jb1,挂Hub航线后):inverse判米饭是否耗尽,未耗尽(仍有免费米饭)则JumpBack打一轮当天双倍图(无视双倍策略,一律吃双倍),打完出栈回本节点自循环;耗尽则null出栈返回Hub继续洞穴.不写on_error(靠出栈自然结束,不触发Panic).max_hit防死循环",
+        "recognition": "Or",
+        "any_of": [
+            "QuickHunt_NoRiceAP_Skip"
         ],
-        "expected": "^[1-9]\\d*/\\d+",
-        "only_rec": true,
+        "inverse": true,
         "max_hit": 20,
+        "next": [
+            "[JumpBack]QuickHunt_RiceRecheck_Hunt",
+            "QuickHunt_RiceRecheck"
+        ],
+        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+    },
+    "QuickHunt_RiceRecheck_Hunt": {
+        "desc": "#327 兜底续打一轮(JumpBack子任务,打完null出栈返回jb1复检):先独立判当前关双倍图打MAX,否则切另一关找双倍/两关都无退狩猎场用光",
         "next": [
             "QuickHunt_RiceRecheck_DoubleCk",
             "QuickHunt_CollectMapAdventureRoute2"
         ],
-        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+        "focus": "BM.#327 打一轮双倍图"
     },
     "QuickHunt_RiceRecheck_DoubleCk": {
         "desc": "#327 兜底:独立判当前关是否双倍图(固定DoubleExp/DoubleGold模板,不受'忽视双倍'override污染);命中(当前关双倍)则打MAX,未命中则miss落到CollectMapAdventureRoute2切另一关找双倍/两关都无则退狩猎场用光",

--- a/assets/resource/base/pipeline/Battle.json
+++ b/assets/resource/base/pipeline/Battle.json
@@ -1157,21 +1157,48 @@
         "focus": "BB.狩猎-复位模块出口\n\n 复位位置正确-成功"
     },
     "QuickHunt_RiceRecheck": {
-        "desc": "#327 免费米饭清空兜底(jb1,挂Hub航线后):inverse判米饭是否耗尽,未耗尽(仍有免费米饭)则JumpBack打一轮当天双倍图(无视双倍策略,一律吃双倍),打完出栈回本节点自循环;耗尽则null出栈返回Hub继续洞穴.不写on_error(靠出栈自然结束,不触发Panic).max_hit防死循环",
+        "desc": "#327 免费米饭清空兜底(jb1,挂Hub航线后):inverse判米饭是否耗尽,未耗尽则续打消化(Hunt强制MAX一轮吃光,故max_hit:1不循环);耗尽则null出栈返回Hub继续洞穴.HuntingGrounds_Entry常闭,UI关航线时开启(优先退狩猎场,避免越权);Hunt复位检查失败则JumpBack调复位模块.不写on_error(靠出栈自然结束,不触发Panic)",
         "recognition": "Or",
         "any_of": [
             "QuickHunt_NoRiceAP_Skip"
         ],
         "inverse": true,
-        "max_hit": 20,
+        "max_hit": 1,
         "next": [
-            "[JumpBack]QuickHunt_RiceRecheck_Hunt",
-            "QuickHunt_RiceRecheck"
+            "QuickHunt_RiceRecheck_HuntingGrounds_Entry",
+            "QuickHunt_RiceRecheck_Hunt",
+            "[JumpBack]QuickHunt_CollectMap_Initialize"
         ],
-        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+        "focus": "BM.#327 免费米饭未清空,续打消化"
+    },
+    "QuickHunt_RiceRecheck_HuntingGrounds_Entry": {
+        "desc": "#327 兜底小入口(常闭):UI关闭航线时由case开启,剩余米饭优先退回狩猎场消化(避免越权把米饭倒入用户关闭的航线);2次失败再落Hunt用航线兜底",
+        "enabled": false,
+        "max_hit": 2,
+        "anchor": {
+            "BattleMap_Reset": ""
+        },
+        "next": [
+            "QuickHunt_CollectMap"
+        ],
+        "focus": "BM.退回打狩猎场"
     },
     "QuickHunt_RiceRecheck_Hunt": {
-        "desc": "#327 兜底续打一轮(JumpBack子任务,打完null出栈返回jb1复检):先独立判当前关双倍图打MAX,否则切另一关找双倍/两关都无退狩猎场用光",
+        "desc": "#327 兜底续打:先And复核复位正确(防前手异常退出),PatchNode强制覆写航线次数MAX(防'狩猎场MAX/双倍图x1'参数污染),再判当前关双倍图打MAX/切另一关找双倍/两关都无退狩猎场",
+        "recognition": "And",
+        "all_of": [
+            "QuickHunt_CollectMap_Initialize_Out_Ty2"
+        ],
+        "action": "Custom",
+        "custom_action": "PatchNode",
+        "custom_action_param": {
+            "node": "QuickHunt_FastBattleMAXTouchAdventureRoute",
+            "patch": {
+                "expected": [
+                    "MAX"
+                ]
+            }
+        },
         "next": [
             "QuickHunt_RiceRecheck_DoubleCk",
             "QuickHunt_CollectMapAdventureRoute2"

--- a/assets/resource/base/pipeline/Battle.json
+++ b/assets/resource/base/pipeline/Battle.json
@@ -1151,9 +1151,50 @@
         ],
         "only_rec": true,
         "next": [
+            "QuickHunt_RiceRecheck",
             "[Anchor]BattleMap_Reset"
         ],
         "focus": "BB.狩猎-复位模块出口\n\n 复位位置正确-成功"
+    },
+    "QuickHunt_RiceRecheck": {
+        "desc": "#327 免费米饭清空兜底复检:复位收口反判米饭余量,分子>0(仍有免费米饭)则回航线找当天双倍图续打(无视双倍策略,一律吃双倍);命中0/N不匹配则跳过本节点,走原收尾锚点.max_hit兜底防极端死循环",
+        "recognition": "OCR",
+        "roi": [
+            1040,
+            33,
+            111,
+            27
+        ],
+        "expected": "^[1-9]\\d*/\\d+",
+        "only_rec": true,
+        "max_hit": 20,
+        "next": [
+            "QuickHunt_RiceRecheck_DoubleCk",
+            "QuickHunt_CollectMapAdventureRoute2"
+        ],
+        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+    },
+    "QuickHunt_RiceRecheck_DoubleCk": {
+        "desc": "#327 兜底:独立判当前关是否双倍图(固定DoubleExp/DoubleGold模板,不受'忽视双倍'override污染);命中(当前关双倍)则打MAX,未命中则miss落到CollectMapAdventureRoute2切另一关找双倍/两关都无则退狩猎场用光",
+        "recognition": "TemplateMatch",
+        "roi": [
+            413,
+            592,
+            159,
+            110
+        ],
+        "template": [
+            "DoubleExp.png",
+            "DoubleGold.png"
+        ],
+        "green_mask": true,
+        "threshold": 0.8,
+        "next": [
+            "QuickHunt_NoAP_Rice",
+            "QuickHunt_FastBattleMAXTouchAdventureRoute",
+            "[JumpBack]QuickHunt_QuickBattleButton"
+        ],
+        "focus": "BM.#327 当前关即双倍图,打MAX消化米饭"
     },
     "QuickHunt_MapLocReset_once": {
         "recognition": "ColorMatch",


### PR DESCRIPTION
## 背景

实现 #327：快速狩猎收尾兜底，避免免费米饭因选项冲突（如「优先双倍 × 当日无双倍」）剩余浪费。源于 #324。

## 方案（采纳 #327 讨论中 @sunyink 的三点意见）

**挂点**：`QuickHunt_Hub.next` 航线之后、洞穴之前插入 jb1（`[JumpBack]QuickHunt_RiceRecheck`）。Hub 是四阶段顺序调度器，jb1 落在「米饭活动（狩猎场+航线）跑完」处，只触发一次；不再像初版挂 `_Out_Ty2`（每场战斗必经、第一场即误触发）。`interface.json` 的「狩猎场MAX/双倍图x1」分配 override 同步插 jb1。

**判定**：`Or` + `any_of:[QuickHunt_NoRiceAP_Skip]` + `inverse` —— 复用现成探针反向判定「米饭未耗尽」。jb1 在洞穴前，只检米饭（不含火把）。

**行动**：`inverse` 命中（还有米饭）→ `[JumpBack]QuickHunt_RiceRecheck_Hunt` 打一轮当天双倍图（`RiceRecheck_DoubleCk` 独立判当前关双倍打 MAX，否则落现有 `CollectMapAdventureRoute2` 切另一关找双倍 / 两关都无退狩猎场用光），打完 null 出栈回 jb1 自循环，直到米饭清零出栈返回 Hub 继续洞穴。**不写 `on_error`**（靠出栈自然结束，不触发 Panic）。`max_hit:20` 防死循环。无视双倍策略、一律吃双倍。

## 改动

46 行新增，2 文件，**洞穴零改动、不改任何现有节点逻辑**。`dev.py check`（base / PC 双组合加载 + 节点引用）已过。

## 待实机验证（合并前会用调试模式取帧精调）

1. jb1 触发时（航线 JumpBack 返回 Hub）的画面状态，`RiceRecheck_DoubleCk` 双倍图 roi `[413,592]` 是否需先进选关界面；
2. JumpBack 续打子任务打完一场能否正确出栈回 jb1；
3. `RiceRecheck_Hunt` 进航线的导航。

火把兜底 jb2 留作后续增强（洞穴本就打到火把光，非 #327 核心）。行动部分 @sunyink 提的「航线/洞穴复用」「左列双倍 up 符号定位」也可在精调阶段一并纳入。

方向若 OK，我把上述实机点精调后更新本 PR。

## Summary by Sourcery

在前往洞穴之前，新增“快速狩猎”回退流程，用于自动消耗剩余的免费大米，具体通过在战斗流水线中加入新的 JumpBack 步骤并更新界面路由来实现。

新功能：
- 引入一个用于快速狩猎大米复查的 JumpBack 节点，在继续主路线之前，反复执行双倍掉率狩猎，直到免费大米耗尽。

改进：
- 更新战斗流水线配置和界面路由，在路线之后、进入洞穴之前插入大米复查步骤，而不更改现有的洞穴逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a quick-hunt fallback flow to automatically consume remaining free rice before proceeding to caves, using a new JumpBack step in the battle pipeline and updated interface routing.

New Features:
- Introduce a QuickHunt rice recheck JumpBack node that reruns double-rate hunts until free rice is exhausted before continuing the main route.

Enhancements:
- Update battle pipeline configuration and interface routing to insert the rice recheck step after routes and before caves without altering existing cave logic.

</details>