### PR TITLE
fix:日常餐馆结算 base两处(green_mask补漏+一键获得识别·#322分流)

### DIFF
--- a/assets/resource/base/pipeline/Daily.json
+++ b/assets/resource/base/pipeline/Daily.json
@@ -197,7 +197,7 @@
         ]
     },
     "Rec_<Daily_Busin_Claim>_Tpl": {
-        "desc": "主页,左侧按钮群-经管2",
+        "desc": "主页,左侧按钮群-经管2。#322 sunyink:原漏green_mask致模板匹配偏低,补green_mask:true",
         "recognition": "TemplateMatch",
         "roi": [
             87,
@@ -208,7 +208,8 @@
         "template": [
             "MainBotmBusinGE.png",
             "MainBotmBusin_F_GE.png"
-        ]
+        ],
+        "green_mask": true
     },
     "Daily_Busin_SubMenu": {
         "desc": "确认餐馆子菜单已弹出",
@@ -238,7 +239,7 @@
         "focus": "DM.经营子菜单 | Err,如果点多了会回到一级主菜单,用err回去"
     },
     "Daily_GetBusin_SubMenu_Claim": {
-        "desc": "在子菜单中ocr领取,结合色核依次点击-获取,与结算分离",
+        "desc": "点击'一键获得'一键领取(结合色核)。#322 sunyink:原expected误写'获得/结算/回收'三子按钮,实应识别'一键获得'单按钮(现靠'获得'左侧优先+颜色AND兜底才未出bug);改识别词'键获得'(det易丢'一')",
         "recognition": "And",
         "all_of": [
             {
@@ -251,9 +252,7 @@
                     416
                 ],
                 "expected": [
-                    "获得",
-                    "结算",
-                    "回收"
+                    "键获得"
                 ]
             },
             "Sub_Ocr_Enable_Clr"


### PR DESCRIPTION
## 背景

#322 review 中 @sunyink 指出两处 base 问题（餐馆结算），按你的建议分流到本分支，daily PR (#322) 内已 cherry-pick 同一 commit。

## 改动（`assets/resource/base/pipeline/Daily.json`，2 处）

1. **`Rec_<Daily_Busin_Claim>_Tpl`**：补漏的 `green_mask:true`。原缺失致 PC 端模板匹配偏低（0.46 < base 0.6，见 #322 review :51）。

2. **`Daily_GetBusin_SubMenu_Claim`**：`expected` 从三子按钮 `["获得","结算","回收"]` → `["键获得"]`。按 review :64——实应识别「一键获得」单按钮（原靠"获得"左侧优先 + 颜色 AND 兜底才未出 bug）；det 易丢"一"，故用"键获得"。

`dev.py check`（base / PC 双组合加载）已过。改动纯逻辑、无需实机。

## Summary by Sourcery

调整每日餐厅结算基础配置，以提升 PC 模板匹配和子菜单识别的准确性。

Bug 修复：
- 为每日营业理赔模板添加缺失的 `green_mask` 标志，以恢复预期的 PC 端匹配置信度。
- 更新每日营业理赔入口的预期子菜单文案，使其正确定位到单个“一键获得”按钮，而不是此前的三个按钮组合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust daily restaurant settlement base configuration to improve PC template matching and submenu recognition accuracy.

Bug Fixes:
- Add missing green_mask flag for the daily business claim template to restore expected PC-side match confidence.
- Update the expected submenu text for the daily business claim entry to correctly target the single '一键获得' button instead of the previous three-button set.

</details>