### PR TITLE
feat:快速狩猎 免费米饭清空兜底复检(#327·换轨main接替#330)

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -378,6 +378,9 @@
                     "pipeline_override": {
                         "QuickHunt_AdventureRoute": {
                             "enabled": false
+                        },
+                        "QuickHunt_RiceRecheck_HuntingGrounds_Entry": {
+                            "enabled": true
                         }
                     }
                 }

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -580,6 +580,7 @@
                                 "[JumpBack]QuickHunt_OpenGui",
                                 "[JumpBack]QuickHunt_AdventureRoute",
                                 "[JumpBack]QuickHunt_HuntingGrounds",
+                                "[JumpBack]QuickHunt_RiceRecheck",
                                 "[JumpBack]QuickHunt_CrystalCave"
                             ]
                         }

--- a/assets/resource/base/pipeline/Battle.json
+++ b/assets/resource/base/pipeline/Battle.json
@@ -1181,21 +1181,48 @@
         "focus": "BB.狩猎-复位模块出口\n\n 复位位置正确-成功"
     },
     "QuickHunt_RiceRecheck": {
-        "desc": "#327 免费米饭清空兜底(jb1,挂Hub航线后):inverse判米饭是否耗尽,未耗尽(仍有免费米饭)则JumpBack打一轮当天双倍图(无视双倍策略,一律吃双倍),打完出栈回本节点自循环;耗尽则null出栈返回Hub继续洞穴.不写on_error(靠出栈自然结束,不触发Panic).max_hit防死循环",
+        "desc": "#327 免费米饭清空兜底(jb1,挂Hub航线后):inverse判米饭是否耗尽,未耗尽则续打消化(Hunt强制MAX一轮吃光,故max_hit:1不循环);耗尽则null出栈返回Hub继续洞穴.HuntingGrounds_Entry常闭,UI关航线时开启(优先退狩猎场,避免越权);Hunt复位检查失败则JumpBack调复位模块.不写on_error(靠出栈自然结束,不触发Panic)",
         "recognition": "Or",
         "any_of": [
             "QuickHunt_NoRiceAP_Skip"
         ],
         "inverse": true,
-        "max_hit": 20,
+        "max_hit": 1,
         "next": [
-            "[JumpBack]QuickHunt_RiceRecheck_Hunt",
-            "QuickHunt_RiceRecheck"
+            "QuickHunt_RiceRecheck_HuntingGrounds_Entry",
+            "QuickHunt_RiceRecheck_Hunt",
+            "[JumpBack]QuickHunt_CollectMap_Initialize"
         ],
-        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+        "focus": "BM.#327 免费米饭未清空,续打消化"
+    },
+    "QuickHunt_RiceRecheck_HuntingGrounds_Entry": {
+        "desc": "#327 兜底小入口(常闭):UI关闭航线时由case开启,剩余米饭优先退回狩猎场消化(避免越权把米饭倒入用户关闭的航线);2次失败再落Hunt用航线兜底",
+        "enabled": false,
+        "max_hit": 2,
+        "anchor": {
+            "BattleMap_Reset": ""
+        },
+        "next": [
+            "QuickHunt_CollectMap"
+        ],
+        "focus": "BM.退回打狩猎场"
     },
     "QuickHunt_RiceRecheck_Hunt": {
-        "desc": "#327 兜底续打一轮(JumpBack子任务,打完null出栈返回jb1复检):先独立判当前关双倍图打MAX,否则切另一关找双倍/两关都无退狩猎场用光",
+        "desc": "#327 兜底续打:先And复核复位正确(防前手异常退出),PatchNode强制覆写航线次数MAX(防'狩猎场MAX/双倍图x1'参数污染),再判当前关双倍图打MAX/切另一关找双倍/两关都无退狩猎场",
+        "recognition": "And",
+        "all_of": [
+            "QuickHunt_CollectMap_Initialize_Out_Ty2"
+        ],
+        "action": "Custom",
+        "custom_action": "PatchNode",
+        "custom_action_param": {
+            "node": "QuickHunt_FastBattleMAXTouchAdventureRoute",
+            "patch": {
+                "expected": [
+                    "MAX"
+                ]
+            }
+        },
         "next": [
             "QuickHunt_RiceRecheck_DoubleCk",
             "QuickHunt_CollectMapAdventureRoute2"

--- a/assets/resource/base/pipeline/Battle.json
+++ b/assets/resource/base/pipeline/Battle.json
@@ -1175,9 +1175,50 @@
         ],
         "only_rec": true,
         "next": [
+            "QuickHunt_RiceRecheck",
             "[Anchor]BattleMap_Reset"
         ],
         "focus": "BB.狩猎-复位模块出口\n\n 复位位置正确-成功"
+    },
+    "QuickHunt_RiceRecheck": {
+        "desc": "#327 免费米饭清空兜底复检:复位收口反判米饭余量,分子>0(仍有免费米饭)则回航线找当天双倍图续打(无视双倍策略,一律吃双倍);命中0/N不匹配则跳过本节点,走原收尾锚点.max_hit兜底防极端死循环",
+        "recognition": "OCR",
+        "roi": [
+            1040,
+            33,
+            111,
+            27
+        ],
+        "expected": "^[1-9]\\d*/\\d+",
+        "only_rec": true,
+        "max_hit": 20,
+        "next": [
+            "QuickHunt_RiceRecheck_DoubleCk",
+            "QuickHunt_CollectMapAdventureRoute2"
+        ],
+        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+    },
+    "QuickHunt_RiceRecheck_DoubleCk": {
+        "desc": "#327 兜底:独立判当前关是否双倍图(固定DoubleExp/DoubleGold模板,不受'忽视双倍'override污染);命中(当前关双倍)则打MAX,未命中则miss落到CollectMapAdventureRoute2切另一关找双倍/两关都无则退狩猎场用光",
+        "recognition": "TemplateMatch",
+        "roi": [
+            413,
+            592,
+            159,
+            110
+        ],
+        "template": [
+            "DoubleExp.png",
+            "DoubleGold.png"
+        ],
+        "green_mask": true,
+        "threshold": 0.8,
+        "next": [
+            "QuickHunt_NoAP_Rice",
+            "QuickHunt_FastBattleMAXTouchAdventureRoute",
+            "[JumpBack]QuickHunt_QuickBattleButton"
+        ],
+        "focus": "BM.#327 当前关即双倍图,打MAX消化米饭"
     },
     "QuickHunt_MapLocReset_once": {
         "recognition": "ColorMatch",

--- a/assets/resource/base/pipeline/Battle.json
+++ b/assets/resource/base/pipeline/Battle.json
@@ -11,6 +11,7 @@
             "[JumpBack]QuickHunt_OpenGui",
             "[JumpBack]QuickHunt_HuntingGrounds",
             "[JumpBack]QuickHunt_AdventureRoute",
+            "[JumpBack]QuickHunt_RiceRecheck",
             "[JumpBack]QuickHunt_CrystalCave"
         ],
         "focus": "B.M 快速狩猎调度器"
@@ -1175,28 +1176,31 @@
         ],
         "only_rec": true,
         "next": [
-            "QuickHunt_RiceRecheck",
             "[Anchor]BattleMap_Reset"
         ],
         "focus": "BB.狩猎-复位模块出口\n\n 复位位置正确-成功"
     },
     "QuickHunt_RiceRecheck": {
-        "desc": "#327 免费米饭清空兜底复检:复位收口反判米饭余量,分子>0(仍有免费米饭)则回航线找当天双倍图续打(无视双倍策略,一律吃双倍);命中0/N不匹配则跳过本节点,走原收尾锚点.max_hit兜底防极端死循环",
-        "recognition": "OCR",
-        "roi": [
-            1040,
-            33,
-            111,
-            27
+        "desc": "#327 免费米饭清空兜底(jb1,挂Hub航线后):inverse判米饭是否耗尽,未耗尽(仍有免费米饭)则JumpBack打一轮当天双倍图(无视双倍策略,一律吃双倍),打完出栈回本节点自循环;耗尽则null出栈返回Hub继续洞穴.不写on_error(靠出栈自然结束,不触发Panic).max_hit防死循环",
+        "recognition": "Or",
+        "any_of": [
+            "QuickHunt_NoRiceAP_Skip"
         ],
-        "expected": "^[1-9]\\d*/\\d+",
-        "only_rec": true,
+        "inverse": true,
         "max_hit": 20,
+        "next": [
+            "[JumpBack]QuickHunt_RiceRecheck_Hunt",
+            "QuickHunt_RiceRecheck"
+        ],
+        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+    },
+    "QuickHunt_RiceRecheck_Hunt": {
+        "desc": "#327 兜底续打一轮(JumpBack子任务,打完null出栈返回jb1复检):先独立判当前关双倍图打MAX,否则切另一关找双倍/两关都无退狩猎场用光",
         "next": [
             "QuickHunt_RiceRecheck_DoubleCk",
             "QuickHunt_CollectMapAdventureRoute2"
         ],
-        "focus": "BM.#327 免费米饭未清空,回航线找双倍图续打"
+        "focus": "BM.#327 打一轮双倍图"
     },
     "QuickHunt_RiceRecheck_DoubleCk": {
         "desc": "#327 兜底:独立判当前关是否双倍图(固定DoubleExp/DoubleGold模板,不受'忽视双倍'override污染);命中(当前关双倍)则打MAX,未命中则miss落到CollectMapAdventureRoute2切另一关找双倍/两关都无则退狩猎场用光",


### PR DESCRIPTION
接替 #330 的换轨 PR：同一功能（免费米饭清空兜底复检，#327），按维护者要求改为直接面向 **main** 发给全版本。

## 为什么开新 PR

#330 的分支基于 feat/NT-Suport，直接改 base 会把整个 NT 历史带进来；按 review 建议需要变基+强推，但本仓库协作习惯不做 force push，故采用与 #331 相同的分流方式：把 `4acbaa9..8ab66ff` 的 3 个提交原样重放到 origin/main 上、新分支常规推送。

## 内容与验证

- 3 个提交零冲突重放（`ef82ec0` / `042355a` / `29c3bae`），与 #330 最终版（`8ab66ff`，已实测"入口和处理都通过"）内容一致
- 对 main 净差异即功能本身：`assets/interface.json +4`、`assets/resource/base/pipeline/Battle.json +72`
- `dev.py check`（ADB/PC 双组合资源加载校验）通过

评审结论与实测记录见 #330。

## 由 Sourcery 提供的摘要

在战斗流水线中新增支持，用于在快速狩猎流程中重新检查并清理 free-rice 兜底逻辑。

新增功能：
- 暴露一个新的接口入口，用于触发快速狩猎 free-rice 兜底逻辑的重新检查流程。
- 扩展战斗流水线配置，使其在快速狩猎过程中执行 free-rice 兜底逻辑的清理与重新校验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support in the battle pipeline for rechecking and clearing the free-rice fallback in 快速狩猎 flows.

New Features:
- Expose a new interface entry to trigger the 快速狩猎 free-rice fallback recheck flow.
- Extend the battle pipeline configuration to perform the free-rice fallback clearing and revalidation logic during 快速狩猎.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了快速狩猎扫荡的流程联动，新增米饭复核相关分支。
  * 当冒险航线关闭时，会改为进入狩猎场前的复核入口，提升后续流程的前置校验。
  * 在特定米饭分配场景下，补充了额外的回跳步骤，确保扫荡流程更稳定地衔接后续处理。

* **Bug 修复**
  * 增加了米饭未清空时的兜底判断与回退处理，减少异常流程中断。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->