### PR TITLE
fix(pipeline): 镜中之战赛季结算期跳过 PVP，避免自动战斗死循环卡死日常队列

### DIFF
--- a/assets/resource/base/pipeline/PVP.json
+++ b/assets/resource/base/pipeline/PVP.json
@@ -153,6 +153,7 @@
         ],
         "threshold": 0.8,
         "next": [
+            "PVP_Results",
             "PVP_AutoBattle",
             "[JumpBack]PVP_PerPetTask",
             "[JumpBack]PVP_PVPMes",
@@ -164,6 +165,18 @@
             "[JumpBack]PVP_Sandplay_NoFindSrena"
         ],
         "focus": "PM.PVP箱庭确认,(2/2)"
+    },
+    "PVP_Results": {
+        "desc": "pvp赛季正在结算中(按印象,缺乏实测)",
+        "recognition": "OCR",
+        "roi": [
+            308,
+            71,
+            210,
+            54
+        ],
+        "expected": "结算中",
+        "next": ["Global_BackToQC1"]
     },
     "PVP_InsandboxAndlocAbnormal": {
         "recognition": "TemplateMatch",

--- a/assets/resource/base/pipeline/PVP.json
+++ b/assets/resource/base/pipeline/PVP.json
@@ -288,6 +288,7 @@
         "post_delay": 1000,
         "next": [
             "PVP_AutoBattle_SucCK",
+            "PVP_SeasonSettling",
             "PVP_AutoBattle"
         ],
         "focus": "PM.PVP.自动战斗-点击(关键节点)"
@@ -314,6 +315,25 @@
             "PVP_JustUseFree"
         ],
         "focus": "PM.PVP.自动战斗(关键节点)-菜单ck"
+    },
+    "PVP_SeasonSettling": {
+        "desc": "镜中之战赛季结算期间,自动战斗菜单被'可在赛季结算完成后确认'弹窗替代,PVP无法进行(奖励顺延至结算),优雅退出避免死循环",
+        "recognition": "OCR",
+        "roi": [
+            327,
+            165,
+            417,
+            156
+        ],
+        "expected": [
+            "结算完成后确认",
+            "结算完成后",
+            "赛季结算"
+        ],
+        "next": [
+            "Global_BackToQC1"
+        ],
+        "focus": "PB.[WRN]镜中之战赛季结算中,跳过PVP"
     },
     "PVP_JustUseFree": {
         "recognition": "ColorMatch",


### PR DESCRIPTION
## 问题
镜中之战（PVP）**赛季结算期间**，日常队列跑到「竞技场」时会死循环卡死，且**导致整条日常队列停摆**——后续「快速狩猎/领取奖励/邮件/商店套利/白嫖抽卡」等任务全部无法执行。

## 根因
结算期点击「自动战斗」后，弹出的是 **「可在赛季结算完成后确认」**，而不是正常的「鲜血鸡尾酒」自动战斗配置菜单。

`PVP_AutoBattle` 原本：
```
next: ["PVP_AutoBattle_SucCK", "PVP_AutoBattle"]
```
`PVP_AutoBattle_SucCK`（roi `[327,165,417,156]`）只识别 `["鲜血鸡尾酒"]`。结算期该 roi 显示的是结算文案，SucCK 永远识别失败 → 在 `PVP_AutoBattle ↔ SucCK` 间无限重试约 **8 分钟（490790ms）**后放弃，队列停摆。

maa.log 证据（`reco_id` 对应 `PVP_AutoBattle_SucCK`）：
```
OCR 命中 {"box":[532,165,204,15],"text":"可在赛李结算完成后确认。"}   ("赛李"=OCR 对"赛季"的误识别)
expected=["鲜血鸡尾酒"] → filtered=[] best=null → 识别失败
```
管线内没有任何节点识别该结算态（`PVP_PerOperationsMain_Error` 只认「没有赛季奖励」，是另一个弹窗，且挂在外层 JumpBack，覆盖不到 `PVP_AutoBattle` 内层循环）。

## 修复
新增 `PVP_SeasonSettling` 节点，插入 `PVP_AutoBattle.next` 的重试之前：
- 复用 `PVP_AutoBattle_SucCK` 的 roi（实测已覆盖弹窗文字位置）；
- `expected` 用「结算完成后」等**稳定子串**，规避「季→李」OCR 误识别；
- 命中后走 **`Global_BackToQC1`**（PVP 正常结束也走它）优雅退出，让日常队列继续。

不新增退出路径、不改动正常 PVP 流程，仅多一条结算态旁路。

## 实测（2026-07-06 赛季结算窗口）
- 修复前：PVP 死循环约 8 分钟后放弃，`日常任务 #4` 及之后全部未执行。
- 修复后：`[Record] PB.[WRN]镜中之战赛季结算中,跳过PVP` → PVP 约 **44 秒**优雅跳过 → 日常一路正常跑完（`任务已全部完成！`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

在竞技场流水线中检测 PVP 赛季结算状态，并跳过自动战斗，以防止每日任务队列卡住。

Bug Fixes:
- 修复赛季结算期间 PVP 自动战斗步骤中的无限重试循环问题，该问题会阻塞后续每日任务。

Enhancements:
- 引入专门的 PVP 赛季结算流水线节点，在不改变正常 PVP 行为的前提下，将流程重新路由回主每日任务流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Detect PVP season settlement state in the arena pipeline and skip auto-battle to prevent the daily task queue from stalling.

Bug Fixes:
- Fix infinite retry loop in the PVP auto-battle step during season settlement that blocked subsequent daily tasks.

Enhancements:
- Introduce a dedicated pipeline node for PVP season settlement that routes back to the main daily flow without altering normal PVP behavior.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增赛季/结算状态跳转节点：在“结算中”与“结算完成/赛季结算”界面出现时，自动进入安全返回流程，绕过不可操作的赛季结算阶段。
* **Bug 修复**
  * 在结算相关提示识别后，自动切换分支以减少卡住与重复循环，提升自动流程连续性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->