### PR TITLE
fix:NT窗口动作.找窗加标题过滤,防误抓其他Unity游戏(补#350)

### DIFF
--- a/agent/action/pc_window.py
+++ b/agent/action/pc_window.py
@@ -18,10 +18,14 @@ TARGET_HEIGHT = 720
 
 # 游戏窗口类名（Win32 controller 里配置的 class_regex）
 WINDOW_CLASS = "UnityWndClass"
+# 游戏窗口标题子串。UnityWndClass 是所有 Unity 游戏共用的类名，
+# 只按类名匹配会误抓同时在跑的其他 Unity 游戏（实测抓到过 Steam 游戏，
+# resize 顶不动 4K 全屏窗口而误报"游戏锁定分辨率"；StopApp 则会误杀）。
+WINDOW_TITLE = "BrownDust"
 
 
 def _find_game_hwnd():
-    """枚举顶层窗口，返回首个类名匹配且可见的游戏窗口 hwnd（找不到返回 HWND(0)，falsy）。
+    """枚举顶层窗口，返回首个 类名+标题 都匹配且可见的游戏窗口 hwnd（找不到返回 HWND(0)，falsy）。
 
     仅 win32；供窗口调整/关闭等动作共享，避免各处各写一份 Unity 窗口枚举而走样。
     """
@@ -36,8 +40,11 @@ def _find_game_hwnd():
         buf = ctypes.create_unicode_buffer(256)
         user32.GetClassNameW(hwnd, buf, 256)
         if buf.value == WINDOW_CLASS and user32.IsWindowVisible(hwnd):
-            found = hwnd
-            return False  # 停止枚举
+            title_buf = ctypes.create_unicode_buffer(256)
+            user32.GetWindowTextW(hwnd, title_buf, 256)
+            if WINDOW_TITLE in title_buf.value:
+                found = hwnd
+                return False  # 停止枚举
         return True
 
     WNDENUMPROC = ctypes.WINFUNCTYPE(
@@ -65,7 +72,7 @@ def _find_and_resize_window() -> tuple[bool, str]:
 
         hwnd = _find_game_hwnd()
         if not hwnd:
-            return False, f"未找到类名为 '{WINDOW_CLASS}' 的游戏窗口，请先启动游戏"
+            return False, f"未找到 '{WINDOW_CLASS}'+标题含'{WINDOW_TITLE}' 的游戏窗口，请先启动游戏"
 
         # 获取窗口标题用于日志
         title_buf = ctypes.create_unicode_buffer(256)
@@ -188,7 +195,7 @@ def _find_and_close_window() -> tuple[bool, str]:
 
         hwnd = _find_game_hwnd()
         if not hwnd:
-            return True, f"未找到 '{WINDOW_CLASS}' 游戏窗口，游戏可能已关闭，跳过"
+            return True, f"未找到 '{WINDOW_CLASS}'+标题含'{WINDOW_TITLE}' 游戏窗口，游戏可能已关闭，跳过"
 
         title_buf = ctypes.create_unicode_buffer(256)
         user32.GetWindowTextW(hwnd, title_buf, 256)

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -11,6 +11,7 @@
             "type": "Win32",
             "win32": {
                 "class_regex": "UnityWndClass",
+                "window_regex": "BrownDust II",
                 "screencap": "FramePool",
                 "mouse": "PostMessageWithWindowPos",
                 "keyboard": "PostMessageWithWindowPos"


### PR DESCRIPTION
## 背景

#350 已合并后实机踩到的新坑，修复未赶上合并，单独补这个 PR。

`UnityWndClass` 是所有 Unity 游戏共用的窗口类名。用户同时开着另一个 Unity 游戏（Steam、4K 全屏）时，`_find_game_hwnd` 只按类名枚举会先撞上它：

- `PC_ResizeWindow` 对着别人家的游戏调分辨率 → 被全屏顶回 → 循环误报"游戏可能锁定了分辨率"（实测调整后客户区恒 2560×1440，MFA 报"pc窗口未找到或调整失败"）；
- `PC_StopApp` 在该状态跑则会**误杀用户正在玩的另一个游戏**。

## 改动

`_find_game_hwnd` 枚举条件由 仅类名 改为 **类名 + 标题含 `BrownDust`** 双条件；找不到时的报错文案带上标题便于排查。

## 验证

实机两个 UnityWndClass 窗口共存（BrownDust II 窗口化 + 另一 Unity 游戏 4K 全屏）：新逻辑正确选中 BrownDust II，不再碰另一窗口。

## Summary by Sourcery

收紧 Windows 游戏窗口的检测逻辑，以避免干扰其他基于 Unity 的游戏，并在目标窗口未找到时改进错误消息。

Bug Fixes:
- 将游戏窗口枚举限制为同时匹配共享的 Unity 窗口类名和 BrownDust 特定标题子串，从而避免选中其他正在运行的 Unity 游戏。
- 更新窗口调整大小和关闭操作的错误消息，使其反映更严格的“类名 + 标题”匹配规则，便于在未找到游戏窗口时进行诊断。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten Windows game window detection to avoid interfering with other Unity-based games and improve error messaging when the target window is not found.

Bug Fixes:
- Restrict game window enumeration to match both the shared Unity window class and a BrownDust-specific title substring to avoid selecting other running Unity games.
- Update resize and close window error messages to reflect the stricter class-plus-title matching, aiding diagnosis when the game window is not found.

</details>