### PR TITLE
fix:NT抽卡.SkipTalk绿蒙版模板补green_mask(#333首版漏配,亮背景下间歇复发)

### DIFF
--- a/assets/resource/pc/pipeline/AutoBattle.json
+++ b/assets/resource/pc/pipeline/AutoBattle.json
@@ -1,9 +1,10 @@
 {
     "AutoBattle_Egress_TurnBack_SkipTalk": {
-        "desc": "场景转换/抽卡展示跳过按钮。|[PC覆盖·2026-07-03实机] PC服装池一键抽后有逐件展示页,右上'>>|'跳过按钮(720约(1169,28)-(1194,48)),base安卓模板Chaga_ProductNext实跑仅0.403<0.7恒miss→Gacha_Quick_Skip永不点跳过→抽后链路(Briefing/Quick_End)全断→Global_ToHomePage真空2分钟(19:46:45~19:48:33实录)→GachaADV_AREA2#装备池被跳过=全量跑漏抽装备根因。此前#333验证时角色池当日已抽过、未走展示页故未暴露。修:从MFA on_error帧(2026.07.03-19.46.24)裁Chaga_ProductNext_PC.png(36x30,图标笔画外绿蒙版背景无关化,自匹配1.000,次高0.456为旁边重播钮,区分充分),追加进template列表(Or语义,base安卓模板保留);战斗场景同款跳过按钮同受益。",
+        "desc": "场景转换/抽卡展示跳过按钮。|[PC覆盖·2026-07-03实机,2026-07-09补green_mask] PC服装池一键抽后有逐件展示页,右上'>>|'跳过按钮(720约(1169,28)-(1194,48)),base安卓模板在PC恒miss→Gacha_Quick_Skip永不点跳过→抽后链路全断→装备池被跳过。修:从MFA on_error帧裁Chaga_ProductNext_PC.png(36x30,图标笔画外涂纯绿背景无关化)追加进template(Or语义)。⚠绿蒙版模板必须配green_mask:true——#333首版漏了,无mask时绿底被当真像素参与CCOEFF,匹配分随展示页背景摇摆(暗背景侥幸0.7+,亮白背景实测0.362,2026-07-09复发实锤;带mask同帧1.000)。base安卓模板无绿像素,green_mask对其无副作用。",
         "template": [
             "Chaga_ProductNext.png",
             "Chaga_ProductNext_PC.png"
-        ]
+        ],
+        "green_mask": true
     }
 }


### PR DESCRIPTION
## 背景（补 #333）

#333 给抽卡展示页跳过按钮加的 PC 模板 `Chaga_ProductNext_PC.png` 是"图标笔画外涂纯绿"的蒙版模板，但首版 pc 覆盖**只加了 `template`、漏配 `green_mask: true`**——绿底被当真像素参与 CCOEFF 匹配，分数随展示页背景摇摆：

- 暗背景：侥幸 >0.7（#333 验证当天正好如此，掩盖了问题）
- 亮白背景：**0.362**（2026-07-09 全量跑复发实锤：服装池抽后逐件展示页 `>>|` 跳过按钮 42 次全 miss → 未点跳过直接超时进下个任务 → 装备池又漏抽）

## 修复

`AutoBattle_Egress_TurnBack_SkipTalk` 补 `"green_mask": true` 一行。

## 验证

复发现场 on_error 帧（`2026.07.09-03.50.00`，亮白教堂背景的服装展示页）离线复核：无 mask CCOEFF = 0.362；**带 mask 同帧 = 1.000**（命中 720(1182,38) 即跳过按钮）。base 安卓模板 `Chaga_ProductNext.png` 无绿像素，green_mask 对其无副作用。

## Summary by Sourcery

错误修复：
- 为 AutoBattle_Egress_TurnBack_SkipTalk 中的 PC SkipTalk / 下一步按钮 模板新增 green_mask 配置，以修复在浅色背景下间歇性漏检的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add green_mask configuration for the PC SkipTalk / 下一步按钮 template in AutoBattle_Egress_TurnBack_SkipTalk to fix intermittent miss-detection on light backgrounds.

</details>