### PR TITLE
Merge:'fix/Iss#339'| 活动图步行吸取,退栈 & 地图子菜单无响应时的复位。

### DIFF
--- a/assets/resource/base/pipeline/Collect_Navigation.json
+++ b/assets/resource/base/pipeline/Collect_Navigation.json
@@ -4,21 +4,17 @@
     },
     "Collect_OperationsMain_Sandplay": {
         "desc": "中断：章节内主要操作开始。找到图钉，确认进入箱庭",
-        "recognition": "TemplateMatch",
-        "roi": [
-            1122,
-            646,
-            40,
-            38
-        ],
-        "template": [
-            "pin.png"
+        "recognition": "Or",
+        "any_of": [
+            "Rec_SandBox_Pin_Tpl",
+            "Rec_SandBox_Run_Tpl"
         ],
         "action": "Custom",
         "custom_action": "ResetTag",
         "custom_action_param": {
             "tags": [
-                "LocPage_SmartSwip"
+                "LocPage_SmartSwip",
+                "Tab3_OnFoot"
             ]
         },
         "anchor": {"Pack_Click": ""},
@@ -35,7 +31,8 @@
         ],
         "on_error": [
             "[JumpBack]Collect_Tab3",
-            "Global_ToSandBox",
+            "[JumpBack]Global_ToSandBox",
+            "Global_QuickCart_MenuReset",
             "Global_Null_Exception",
             "Global_Null_Panic"
         ],

--- a/assets/resource/base/pipeline/Collect_Navigation.json
+++ b/assets/resource/base/pipeline/Collect_Navigation.json
@@ -14,7 +14,8 @@
         "custom_action_param": {
             "tags": [
                 "LocPage_SmartSwip",
-                "Tab3_OnFoot"
+                "Tab3_OnFoot",
+                "NviMap_Sub_Err"
             ]
         },
         "anchor": {"Pack_Click": ""},

--- a/assets/resource/base/pipeline/Collect_TeleportRecall.json
+++ b/assets/resource/base/pipeline/Collect_TeleportRecall.json
@@ -1,16 +1,24 @@
 {
     "Collect_Tab3": {
-        "desc": "传送阵寻回模块.技能&步行.",
-        "recognition": "TemplateMatch",
-        "roi": [
-            1108,
-            637,
-            65,
-            57
+        "desc": "传送阵寻回模块.技能&步行.JB退栈在复位后",
+        "recognition": "And",
+        "all_of": [
+            {
+                "recognition": "Custom",
+                "custom_recognition": "CheckTag",
+                "custom_recognition_param": {
+                    "tag": "Tab3_OnFoot",
+                    "max": 1
+                }
+            },
+            "Rec_SandBox_Pin_Tpl"
         ],
-        "template": [
-            "pin.png"
-        ],
+        "action": "Custom",
+        "custom_action": "UpdateTag",
+        "custom_action_param": {
+            "tag": "Tab3_OnFoot",
+            "value": 1
+        },
         "next": [
             "Collect_Tab3_Ck",
             "[JumpBack]Collect_Tab3_Switch"
@@ -350,6 +358,7 @@
             34,
             38
         ],
+        "post_delay": 2500,
         "next": [
             "Collect_TeleporCircle_OnFoot_NviMap",
             "Collect_TeleporCircle_OnFoot_GoinNviMap"

--- a/assets/resource/base/pipeline/Collect_TeleportRecall.json
+++ b/assets/resource/base/pipeline/Collect_TeleportRecall.json
@@ -520,7 +520,7 @@
         ]
     },
     "Collect_IM_OnFoot_NviMap_E01_A2_Move_Sub": {
-        "max_hit": 5,
+        "desc": "区域图.图标子菜单",
         "recognition": "OCR",
         "roi": [
             121,
@@ -539,14 +539,41 @@
             0
         ],
         "post_delay": 4000,
+        "timeout": 8000,
         "next": [
             "[JumpBack]Collect_IM_OnFoot_Moveing",
             "Collect_IM_OnFoot_NviMap_2_Move_End",
             "[JumpBack]Collect_IM_Move_MGS",
-            "[JumpBack]Global_WaitingForLoading",
-            "Collect_IM_OnFoot_NviMap_E01_A2_Move_Sub"
+            "[JumpBack]Global_WaitingForLoading"
+        ],
+        "on_error": [
+            "Collect_IM_OnFoot_NviMap_Sub_Err",
+            "Global_Null"
         ],
         "focus": "小地图图标子菜单"
+    },
+    "Collect_IM_OnFoot_NviMap_Sub_Err": {
+        "recognition": "Custom",
+        "custom_recognition": "CheckTag",
+        "custom_recognition_param": {
+            "tag": "NviMap_Sub_Err",
+            "max": 5
+        },
+        "action": "Custom",
+        "custom_action": "UpdateTag",
+        "custom_action_param": {
+            "tag": "NviMap_Sub_Err",
+            "value": 1
+        },
+        "next": [
+            "Collect_IM_OnFoot_NviMap_Sub_Err_Out",
+            "[JumpBack]Global_ToSandBox"
+        ]
+    },
+    "Collect_IM_OnFoot_NviMap_Sub_Err_Out": {
+        "recognition": "Or",
+        "any_of": ["Global_ToSandBox_Enter"],
+        "next": ["Collect_TeleporCircle_OnFoot_Start"]
     },
     "Collect_IM_OnFoot_NviMap_E01_B2_Move": {
         "max_hit": 5,
@@ -567,6 +594,7 @@
         ]
     },
     "Collect_IM_OnFoot_Moveing": {
+        "desc": "自动移动中",
         "recognition": "Or",
         "any_of": [
             "Rec_SandBox_Moveing_Tpl",
@@ -834,7 +862,6 @@
         ]
     },
     "Collect_IM_OnFoot_NviMap_E03_A2_Move_Sub": {
-        "max_hit": 5,
         "recognition": "OCR",
         "roi": [
             347,
@@ -857,8 +884,11 @@
             "[JumpBack]Collect_IM_OnFoot_Moveing",
             "Collect_IM_OnFoot_NviMap_2_Move_End",
             "[JumpBack]Collect_IM_Move_MGS",
-            "[JumpBack]Global_WaitingForLoading",
-            "Collect_IM_OnFoot_NviMap_E03_A2_Move_Sub"
+            "[JumpBack]Global_WaitingForLoading"
+        ],
+        "on_error": [
+            "Collect_IM_OnFoot_NviMap_Sub_Err",
+            "Global_Null"
         ],
         "focus": "小地图图标子菜单"
     },

--- a/assets/resource/base/pipeline/Collect_TeleportRecall.json
+++ b/assets/resource/base/pipeline/Collect_TeleportRecall.json
@@ -946,6 +946,7 @@
         "template": [
             "Nvimap_Butt_right.png"
         ],
+        "timeout": 5000,
         "next": [
             "Collect_TeleporCircle_OnFoot_TPIco",
             "Collect_TeleporCircle_OnFoot_NviMap_GoHotel",
@@ -964,6 +965,7 @@
         "template": [
             "Nvimap_Butt_right.png"
         ],
+        "timeout": 5000,
         "next": [
             "Collect_TeleporCircle_OnFoot_TPIco",
             "Collect_TeleporCircle_OnFoot_NviMap_IsSafeArea_NotHotel",


### PR DESCRIPTION
## Summary by Sourcery

调整集合导航和传送回溯（teleport recall）管线配置，以解决交互问题。

错误修复：
- 修复与吸收和堆叠处理相关的 activity-map 行走集合行为。
- 在集合导航过程中，当地图子菜单变得无响应时重置其状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust collection navigation and teleport recall pipeline configurations to resolve interaction issues.

Bug Fixes:
- Fix activity-map walking collection behavior related to absorption and stack handling.
- Reset map sub-menu state when it becomes unresponsive during collection navigation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 增强导航与传送召回流程识别范围，支持多模板匹配并引入基于标记的状态校验触发。
  * 优化小地图图标子菜单与自动移动状态的流程编排，并补充关键步骤的超时与延迟控制。

* **Bug Fixes**
  * 调整错误恢复路径与回退顺序，增加重置菜单环节以提升恢复稳定性。
  * 修正部分子菜单/移动节点的路由与兜底分支，减少无效循环并提升失败时的可达回退。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->