### PR TITLE
feat:红点识别.增加泛用严格HSV救援

### DIFF
--- a/agent/recognition/binarymatch.py
+++ b/agent/recognition/binarymatch.py
@@ -15,6 +15,15 @@ from maa.define import RectType
 
 from utils import mfaalog
 from .rdd_sampler import RddSampler
+from .rdd_hsv_rescue import (
+    build_topology_states,
+    is_strict_mask,
+    lineage_parent,
+    mask_digest,
+    normalize_rescue_config,
+    select_stable_winner,
+    strict_profile,
+)
 
 
 # ================================================================
@@ -361,6 +370,9 @@ class HSVShapeMatching(CustomRecognition):
 #                          大 ROI 泛找可调高到 0.58。
 #   gap_ratio      (float) 仅用于 detail 里 gap 的"是否成双段"标注，不再作命中门槛。
 #   preset         (str)   预设节点名（预设模式）。
+#   flt_hsv_rescue (object) 严格 HSV 拓扑救援。mode=off/shadow/active；仅 baseline
+#                          最终卡 aspect 时提高 S/V lower，严格子集经 lineage+跨档稳定
+#                          后才可命中。默认 off；预算/歧义/异常均 fail closed。
 #   注：旧的 inner_v_min / inner_s_max 已弃用(绝对亮度阈值在模糊下会掉崖)，若残留会被忽略。
 #
 # [可观测性 —— 金字塔回调 + vision 调试图]
@@ -399,7 +411,7 @@ class HSVShapeMatching(CustomRecognition):
 #   筛选·红掩膜  → HSV 没框到红色：降低 S/V 下限 / 校正 roi
 #   筛选·面积    → 面积不在 red_area：多半 min 太大
 #   筛选·长宽比  → 红块 h/w 出圈(看 aspect_rej)：横条/竖柱杂红=正常拒；
-#                  连片真货被误杀→优先收紧 flt_red_hsv 拆连片，其次放宽 flt_aspect
+#                  连片真货由 flt_hsv_rescue 严格 HSV 搜索拆开；不要放宽 flt_aspect
 #   筛选·内部    → 红块内无封闭非红区(无感叹号轮廓)：roi 偏移 / 红圈破损 / 被模糊填满
 #   打分        → 看「明细」贡献列：竖长/偏白低=非感叹号(正常拒)；真货被拒才降 min_confidence
 #
@@ -454,8 +466,8 @@ class HSVShapeMatching(CustomRecognition):
 # 文件名以"节点名+ROI"为 key，同检测点重复失败直接覆盖。
 #
 # 失败原因结构化写入 detail，通过 MaaLogs 工具可复盘（图没了也能看数据）：
-#   detail.stage           卡在哪个阶段（red_mask / area / interior / confidence）
-#   detail.hint            具体提示与修正方向
+#   detail.阶段 / 卡在     筛选(red_mask / area / aspect / interior)或打分
+#   detail.说明            具体提示与修正方向
 #   detail.stat.conf       最高候选置信分（confidence 阶段专用）
 #   detail.stat.parts      各分项得分 {gap, vert, white, cent}
 #   detail.stat.proj       垂直投影数组（按行的封闭区像素数，用于判断双段）
@@ -500,7 +512,14 @@ class HSVShapeMatching(CustomRecognition):
 # area_pass=0 → 所有 blob 被过滤，多半 min 太大。
 #
 # ────────────────────────────────────────────────────────────────
-# 阶段 4a  拓扑封闭取内部区（detail.stage = "interior"）
+# 阶段 4  红块 h/w 筛选（detail.卡在 = "aspect"）
+# ────────────────────────────────────────────────────────────────
+# 参数：flt_aspect [min,max]，默认 [0.6,1.6]。
+# 横条/竖柱正常拒绝；若所有面积候选均卡在此处，可由 flt_hsv_rescue 在严格子集、
+# lineage、跨档稳定与预算约束下尝试拆开连片。禁止直接放宽 flt_aspect。
+#
+# ────────────────────────────────────────────────────────────────
+# 阶段 5  拓扑封闭取内部区（detail.卡在 = "interior"）
 # ────────────────────────────────────────────────────────────────
 # 输出：rdd_*_inner.png  ← 黑=enclosed（被红色真正包围的非红像素）
 #
@@ -514,7 +533,7 @@ class HSVShapeMatching(CustomRecognition):
 #   · 极度模糊时红色"填满"感叹号缝隙，封闭区消失（物理边界，无法靠参数解决）
 #
 # ────────────────────────────────────────────────────────────────
-# 阶段 4b  置信度加权评分 v2（detail.阶段 = "打分"）
+# 阶段 6  置信度加权评分 v2（detail.阶段 = "打分"）
 # ────────────────────────────────────────────────────────────────
 # 参数：min_confidence（默认 0.55；必须 > 最大单项权重 0.45 → 命中需两项背书）
 # 数据：detail.打分 = {总分, 阈值, 通过, 明细:[每项 值/权重/贡献]}
@@ -558,6 +577,7 @@ class HSVShapeMatching(CustomRecognition):
 # ────────────────────────────────────────────────────────────────
 # 筛选·红掩膜(red_mask)  → red_mask 全白：降 hsv_ranges S/V 下限 / 校 roi
 # 筛选·面积(area)        → area_pass=0：降 red_area min（或升 max）
+# 筛选·长宽比(aspect)    → 连片真货仅走 flt_hsv_rescue；不要放宽 flt_aspect
 # 筛选·内部(interior)    → inner 全白：红圈破损或模糊填满，缩小 roi / 等清晰帧
 # 打分(confidence)       → 看明细贡献列：竖长/偏白低=非感叹号(拒对了)；真货被拒才降 min_confidence
 # 大 ROI 误判杂红         → 提高 min_confidence 到 0.58
@@ -720,21 +740,27 @@ class RedDotDetector(CustomRecognition):
             })
 
         caller_node = getattr(argv, "node_name", "") or preset_node
+        raw = getattr(reco, "raw_detail", None) or {}
 
         # 预设模式：整屏在本级手里，由本级做原生回显(命中/未命中都画，嵌套层不画)
         echo_hsv, echo_area = self._preset_echo_params(context, preset_node)
-        self._emit_native_vision(context, caller_node, (rx, ry, rw, rh),
-                                 argv.image, echo_hsv, echo_area)
+        effective_hsv = self._find_nested(raw, "effective_hsv_ranges") or echo_hsv
 
         if reco.hit:
             bx, by, bw, bh = reco.box
             adjusted = (bx + rx, by + ry, bw, bh)
+            self._emit_native_vision(
+                context, caller_node, (rx, ry, rw, rh), argv.image,
+                effective_hsv, echo_area, result_box=adjusted)
             mfaalog.info(f"[RedDotDetector] [preset:{preset_node}] hit -> {adjusted}")
             return CustomRecognition.AnalyzeResult(
-                box=adjusted, detail={"result": "hit", "preset": preset_node})
+                box=adjusted, detail={"result": "hit", "mode": "preset",
+                                      "preset": preset_node,
+                                      "preset_detail": raw})
 
         # 真未命中：阶段原因已由预设节点(独立模式)记进嵌套识别记录；这里附带透传其 raw_detail
-        raw = getattr(reco, "raw_detail", None) or {}
+        self._emit_native_vision(context, caller_node, (rx, ry, rw, rh),
+                                 argv.image, effective_hsv, echo_area)
         mfaalog.warning(f"[RedDotDetector] miss@preset | {argv.node_name} via {preset_node}")
         return CustomRecognition.AnalyzeResult(box=None, detail={
             "result": "miss", "mode": "preset", "preset": preset_node,
@@ -742,6 +768,23 @@ class RedDotDetector(CustomRecognition):
             "preset_detail": raw,
             "hint": "阶段原因见预设节点(独立模式)的 detail；失败截图见 debug/RedDotDetector/ 下以本节点名命名的 rdd_* 文件",
         })
+
+    @staticmethod
+    def _find_nested(value, key):
+        """在 Maa raw_detail 的不同包装层中取自定义 detail 字段。"""
+        if isinstance(value, dict):
+            if key in value:
+                return value[key]
+            for child in value.values():
+                found = RedDotDetector._find_nested(child, key)
+                if found is not None:
+                    return found
+        elif isinstance(value, list):
+            for child in value:
+                found = RedDotDetector._find_nested(child, key)
+                if found is not None:
+                    return found
+        return None
 
     # ------------------------------------------------------------------
     # 独立模式
@@ -755,7 +798,7 @@ class RedDotDetector(CustomRecognition):
     def _normalize_params(self, params: dict) -> dict:
         out = dict(params)
         for new, old in self._PARAM_ALIAS.items():
-            if new in params and old not in out:
+            if new in params:
                 out[old] = params[new]
         return out
 
@@ -768,6 +811,9 @@ class RedDotDetector(CustomRecognition):
         asp_lo, asp_hi = params.get("flt_aspect", _FLT_ASPECT_DEFAULT)
         gap_ratio = params.get("gap_ratio", 0.35)      # 仅用于 detail 的 gap 标注
         min_conf = params.get("min_confidence", _SC_MIN_CONF)
+        rescue_cfg, rescue_error = normalize_rescue_config(params.get("flt_hsv_rescue"))
+        if rescue_error and "flt_hsv_rescue" in params:
+            print(f"[RedDotDetector] HSV 救援配置无效，已关闭: {rescue_error}")
 
         # 1. 按 roi 裁剪
         roi = argv.roi
@@ -791,15 +837,81 @@ class RedDotDetector(CustomRecognition):
         # 2. HSV → 红色掩膜
         pil_img = Image.fromarray(work_bgr[..., ::-1])
         hsv_np = np.array(pil_img.convert("HSV"))
-        red_mask = _compute_hsv_mask(hsv_np, hsv_ranges)
+        baseline = self._detect_once(
+            hsv_np, hsv_ranges, area_min, area_max, asp_lo, asp_hi,
+            gap_ratio, min_conf, rx, ry,
+        )
+        if baseline["hit"]:
+            return self._finalize_hit(
+                context=context, argv=argv, node=node, key_roi=key_roi,
+                caller=caller, work_bgr=work_bgr, roi_tuple=(rx, ry, rw, rh),
+                params=params, area_range=(area_min, area_max),
+                aspect_range=(asp_lo, asp_hi), gap_ratio=gap_ratio,
+                min_conf=min_conf, outcome=baseline,
+                candidate=baseline["candidates"][0],
+                effective_hsv=hsv_ranges, rescue=None,
+            )
 
-        # 3. 连通域
-        labeled, n_blobs = _label_blobs(red_mask)
+        stage, hint = self._diagnose(baseline["stat"], area_min, area_max, min_conf)
+        rescue = None
+        if stage == "aspect" and rescue_cfg["mode"] != "off":
+            try:
+                rescue = self._run_hsv_rescue(
+                    hsv_np=hsv_np, baseline=baseline, hsv_ranges=hsv_ranges,
+                    area_range=(area_min, area_max), aspect_range=(asp_lo, asp_hi),
+                    gap_ratio=gap_ratio, min_conf=min_conf, rx=rx, ry=ry,
+                    config=rescue_cfg,
+                )
+            except Exception:
+                rescue = {
+                    "mode": rescue_cfg["mode"], "attempted": True,
+                    "trigger": "stage_aspect", "decision": "error",
+                    "stop_reason": "exception",
+                    "error": traceback.format_exc().strip().splitlines()[-1],
+                }
+                print(f"[RedDotDetector] HSV 救援异常，保持 baseline miss:\n"
+                      f"{traceback.format_exc()}")
+            winner = rescue.get("_winner")
+            if (winner is not None and rescue_cfg["mode"] == "active"
+                    and rescue.get("search_complete")
+                    and rescue.get("decision") == "stable_hit"):
+                return self._finalize_hit(
+                    context=context, argv=argv, node=node, key_roi=key_roi,
+                    caller=caller, work_bgr=work_bgr, roi_tuple=(rx, ry, rw, rh),
+                    params=params, area_range=(area_min, area_max),
+                    aspect_range=(asp_lo, asp_hi), gap_ratio=gap_ratio,
+                    min_conf=min_conf, outcome=winner["outcome"],
+                    candidate=winner["candidate"],
+                    effective_hsv=winner["profile"],
+                    rescue=self._public_rescue(rescue),
+                )
+
+        return self._finalize_miss(
+            context=context, argv=argv, node=node, key_roi=key_roi,
+            caller=caller, work_bgr=work_bgr, roi_tuple=(rx, ry, rw, rh),
+            params=params, hsv_ranges=hsv_ranges,
+            area_range=(area_min, area_max),
+            aspect_range=(asp_lo, asp_hi), min_conf=min_conf,
+            baseline=baseline, stage=stage, hint=hint,
+            rescue=self._public_rescue(rescue),
+        )
+
+    def _detect_once(self, hsv_np, hsv_ranges, area_min, area_max,
+                     asp_lo, asp_hi, gap_ratio, min_conf, rx, ry,
+                     red_mask=None, labeled=None, collect_all=False):
+        """无日志、采样、回显副作用的单轮检测核心。"""
+        red_mask = (_compute_hsv_mask(hsv_np, hsv_ranges)
+                    if red_mask is None else red_mask)
+        if labeled is None:
+            labeled, n_blobs = _label_blobs(red_mask)
+        else:
+            n_blobs = int(labeled.max()) if labeled.size else 0
+
         stat = {"red_px": int(red_mask.sum()), "n_blobs": int(n_blobs),
                 "area_pass": 0, "aspect_pass": 0, "max_inner_px": 0, "scored": 0}
         best, best_mask, best_box_local = None, None, None
+        candidates, eligible_parents = [], []
 
-        # 4. 逐 blob 检测
         for i in range(1, n_blobs + 1):
             blob = (labeled == i)
             area = int(np.sum(blob))
@@ -812,27 +924,26 @@ class RedDotDetector(CustomRecognition):
             bx0, bx1 = int(cols[0]), int(cols[-1])
             by0, by1 = int(rows[0]), int(rows[-1])
             bw, bh = bx1 - bx0 + 1, by1 - by0 + 1
-
-            # 筛选·长宽比：真红点 h/w≈1，横条/实心柱杂红在圈外。被拒 blob 的几何
-            # 记进 aspect_rej(最多3个)随 detail/语料下发，供定标复核连片真货是否被误杀。
             aspect = round(bh / max(bw, 1), 2)
+            geometry = {"label": i, "x": bx0, "y": by0, "w": bw, "h": bh,
+                        "area": area, "aspect": aspect,
+                        "fill": round(area / max(bw * bh, 1), 2)}
             if not (asp_lo <= aspect <= asp_hi):
+                eligible_parents.append(geometry)
                 if len(stat.setdefault("aspect_rej", [])) < 3:
                     stat["aspect_rej"].append(
-                        {"w": bw, "h": bh, "area": area, "aspect": aspect,
-                         "fill": round(area / max(bw * bh, 1), 2)})
+                        {k: geometry[k] for k in ("w", "h", "area", "aspect", "fill")})
                 continue
             stat["aspect_pass"] += 1
 
             box_red = red_mask[by0:by1 + 1, bx0:bx1 + 1]
             box_hsv = hsv_np[by0:by1 + 1, bx0:bx1 + 1]
-
-            # 拓扑封闭过滤：排除矩形四角能触达边框的背景，只留被红色真正包围的内部
-            # 不卡绝对亮度——白被模糊压暗也照取，由偏白"对比"在打分时衡量
             non_red_crop = ~box_red
             labeled_crop, _ = _label_blobs(non_red_crop)
-            border_labels = (set(labeled_crop[0, :].tolist()) | set(labeled_crop[-1, :].tolist())
-                             | set(labeled_crop[:, 0].tolist()) | set(labeled_crop[:, -1].tolist()))
+            border_labels = (set(labeled_crop[0, :].tolist())
+                             | set(labeled_crop[-1, :].tolist())
+                             | set(labeled_crop[:, 0].tolist())
+                             | set(labeled_crop[:, -1].tolist()))
             border_labels.discard(0)
             enclosed = non_red_crop & ~np.isin(labeled_crop, list(border_labels))
 
@@ -841,11 +952,9 @@ class RedDotDetector(CustomRecognition):
             if enc_px == 0:
                 continue
 
-            chk = self._exclamation_info(enclosed, gap_ratio)       # 投影/断层(供 f_gap 与诊断)
+            chk = self._exclamation_info(enclosed, gap_ratio)
             conf, parts = self._confidence(box_hsv, box_red, enclosed, chk)
-            # 红块几何：aspect 已过闸；fill 是 v3 下一维度的定标观测量(只记录不闸门)
-            red_blob = {"w": bw, "h": bh, "area": area, "aspect": aspect,
-                        "fill": round(area / max(bw * bh, 1), 2)}
+            red_blob = {k: geometry[k] for k in ("w", "h", "area", "aspect", "fill")}
             if best is None or conf > best["conf"]:
                 best = {"conf": conf, "parts": parts, "red_blob": red_blob, **chk}
                 best_mask = enclosed
@@ -853,73 +962,330 @@ class RedDotDetector(CustomRecognition):
 
             stat["scored"] += 1
             if conf >= min_conf:
-                result_box = (bx0 + rx, by0 + ry, bw, bh)
-                mfaalog.info(f"[RedDotDetector] hit | box={result_box} conf={conf} {parts}")
-                # 命中也画：误命中现场需要可视化复盘
-                hit_stat = {**stat, "conf": conf, "parts": parts, "red_blob": red_blob,
-                            "proj": chk.get("proj"),
-                            "gap": {"row": chk.get("gap_row"), "val": chk.get("gap_val"),
-                                    "peak": chk.get("peak"), "ratio": chk.get("ratio"),
-                                    "above_nz": chk.get("above_nz"), "has_below": chk.get("has_below")}}
-                dbg_text = self._compose_dbg(params, hit_stat, f"result: HIT box={list(result_box)}", min_conf)
-                print(f"[RedDotDetector] {node}\n{dbg_text}")
-                _SAMPLER.record(
-                    node=node, roi=key_roi, result="hit",
-                    images={"roi_crop": work_bgr, "red_mask": red_mask, "inner": enclosed},
-                    meta={"mode": "preset" if caller else "standalone",
-                          "box": list(result_box), "conf": conf, "parts": parts,
-                          "red_blob": red_blob, "proj": chk.get("proj"),
-                          "params": {"hsv_ranges": hsv_ranges,
-                                     "red_area": [area_min, area_max],
-                                     "min_conf": min_conf}})
-                if caller is None:   # 非预设：本级持有整屏，直接做原生回显
-                    self._emit_native_vision(context, node, (rx, ry, rw, rh),
-                                             argv.image, hsv_ranges, area_min)
-                return CustomRecognition.AnalyzeResult(
-                    box=result_box,
-                    detail={"result": "hit", "阶段": "打分",
-                            "打分": self._score_breakdown(parts, conf, min_conf),
-                            "red_area": area, "red_blob": red_blob, "box": list(result_box),
-                            "conf": conf, "parts": parts, "dbg": dbg_text})  # conf/parts/dbg 随识别记录进日志，供复盘
+                candidate = {
+                    "scan_index": i,
+                    "label": i,
+                    "box_local": (bx0, by0, bw, bh),
+                    "result_box": (bx0 + rx, by0 + ry, bw, bh),
+                    "blob_mask": blob,
+                    "inner": enclosed,
+                    "conf": conf,
+                    "parts": parts,
+                    "red_blob": red_blob,
+                    "chk": chk,
+                }
+                candidates.append(candidate)
+                if not collect_all:
+                    stat.update(self._candidate_stat(candidate))
+                    return {
+                        "hit": True, "candidates": candidates, "stat": stat,
+                        "red_mask": red_mask, "labeled": labeled,
+                        "eligible_parents": eligible_parents,
+                        "best_mask": enclosed, "best_box_local": candidate["box_local"],
+                    }
 
-        # 5. 未命中：置信/投影/断层进 stat → detail；落盘失败图；统一出口
         if best is not None:
             stat["conf"] = best["conf"]
             stat["parts"] = best["parts"]
             stat["red_blob"] = best["red_blob"]
             stat["proj"] = best["proj"]
-            stat["gap"] = {"row": best["gap_row"], "val": best["gap_val"], "peak": best["peak"],
-                           "ratio": best["ratio"], "above_nz": best["above_nz"],
+            stat["gap"] = {"row": best["gap_row"], "val": best["gap_val"],
+                           "peak": best["peak"], "ratio": best["ratio"],
+                           "above_nz": best["above_nz"],
                            "has_below": best["has_below"]}
             stat["best_box"] = list(best_box_local) if best_box_local else None
 
-        stage, hint = self._diagnose(stat, area_min, area_max, min_conf)
-        dbg_text = self._compose_dbg(params, stat, f"result: MISS ({stage}) {hint}", min_conf)
-        self._dump_failure(node, key_roi, work_bgr, red_mask, best_mask)
-        miss_imgs = {"roi_crop": work_bgr, "red_mask": red_mask}
-        if best_mask is not None:
-            miss_imgs["inner"] = best_mask
+        return {
+            "hit": bool(candidates), "candidates": candidates, "stat": stat,
+            "red_mask": red_mask, "labeled": labeled,
+            "eligible_parents": eligible_parents,
+            "best_mask": best_mask, "best_box_local": best_box_local,
+        }
+
+    @staticmethod
+    def _candidate_stat(candidate):
+        chk = candidate["chk"]
+        return {
+            "conf": candidate["conf"],
+            "parts": candidate["parts"],
+            "red_blob": candidate["red_blob"],
+            "proj": chk.get("proj"),
+            "gap": {"row": chk.get("gap_row"), "val": chk.get("gap_val"),
+                    "peak": chk.get("peak"), "ratio": chk.get("ratio"),
+                    "above_nz": chk.get("above_nz"),
+                    "has_below": chk.get("has_below")},
+        }
+
+    def _preview_rescue(self, labeled, baseline_labels, eligible_ids,
+                        area_min, area_max, asp_lo, asp_hi):
+        """只做 area/aspect/lineage，避免对无望 profile 完整打分。"""
+        feasible = []
+        n_blobs = int(labeled.max()) if labeled.size else 0
+        for i in range(1, n_blobs + 1):
+            blob = (labeled == i)
+            area = int(blob.sum())
+            if not (area_min <= area <= area_max):
+                continue
+            ys, xs = np.where(blob)
+            bw, bh = int(xs.max() - xs.min() + 1), int(ys.max() - ys.min() + 1)
+            aspect = round(bh / max(bw, 1), 2)
+            if not (asp_lo <= aspect <= asp_hi):
+                continue
+            parent_id = lineage_parent(blob, baseline_labels, eligible_ids)
+            if parent_id is not None:
+                feasible.append({"label": i, "parent_id": parent_id})
+        return feasible
+
+    def _run_hsv_rescue(self, *, hsv_np, baseline, hsv_ranges, area_range,
+                        aspect_range, gap_ratio, min_conf, rx, ry, config):
+        """受约束的严格 HSV 拓扑断点搜索；返回内部 winner 与可序列化轨迹。"""
+        started = time.perf_counter()
+        area_min, area_max = area_range
+        asp_lo, asp_hi = aspect_range
+        eligible_ids = [item["label"] for item in baseline["eligible_parents"]]
+        eligible_mask = np.isin(baseline["labeled"], eligible_ids)
+        states = build_topology_states(hsv_np, eligible_mask, hsv_ranges, config)
+        seen_masks, attempts, hit_records = set(), [], []
+        state_space_truncated = bool(getattr(states, "truncated", False))
+        full_runs = 0
+        stop_reason = "state_budget" if state_space_truncated else "states_exhausted"
+        search_complete = not state_space_truncated
+
+        for state in states:
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            if elapsed_ms >= config["time_budget_ms"]:
+                stop_reason = "time_budget"
+                search_complete = False
+                break
+            profile = strict_profile(
+                hsv_ranges, state["delta_s"], state["delta_v"])
+            if profile is None:
+                continue
+            red_mask = _compute_hsv_mask(hsv_np, profile)
+            if (time.perf_counter() - started) * 1000 >= config["time_budget_ms"]:
+                stop_reason = "time_budget"
+                search_complete = False
+                break
+            if not is_strict_mask(red_mask, baseline["red_mask"]):
+                continue
+            digest = mask_digest(red_mask)
+            if digest in seen_masks:
+                continue
+            seen_masks.add(digest)
+            labeled, n_blobs = _label_blobs(red_mask)
+            if (time.perf_counter() - started) * 1000 >= config["time_budget_ms"]:
+                stop_reason = "time_budget"
+                search_complete = False
+                break
+            feasible = self._preview_rescue(
+                labeled, baseline["labeled"], eligible_ids,
+                area_min, area_max, asp_lo, asp_hi,
+            )
+            attempt = {
+                "state": dict(state), "red_px": int(red_mask.sum()),
+                "n_blobs": int(n_blobs), "feasible": len(feasible),
+                "full_run": False, "hits": [],
+            }
+            if not feasible:
+                attempts.append(attempt)
+                continue
+            if full_runs >= config["max_full_runs"]:
+                stop_reason = "full_run_budget"
+                search_complete = False
+                attempts.append(attempt)
+                break
+
+            outcome = self._detect_once(
+                hsv_np, profile, area_min, area_max, asp_lo, asp_hi,
+                gap_ratio, min_conf, rx, ry,
+                red_mask=red_mask, labeled=labeled, collect_all=True,
+            )
+            full_runs += 1
+            attempt["full_run"] = True
+            over_time = ((time.perf_counter() - started) * 1000
+                         >= config["time_budget_ms"])
+            for candidate in outcome["candidates"]:
+                parent_id = lineage_parent(
+                    candidate["blob_mask"], baseline["labeled"], eligible_ids)
+                if parent_id is None:
+                    continue
+                record = {
+                    "state": dict(state), "parent_id": parent_id,
+                    "box_local": candidate["box_local"],
+                    "scan_index": candidate["scan_index"],
+                    "candidate": candidate, "outcome": outcome,
+                    "profile": profile,
+                }
+                hit_records.append(record)
+                attempt["hits"].append({
+                    "parent_id": parent_id,
+                    "box": list(candidate["box_local"]),
+                    "conf": candidate["conf"],
+                })
+            attempts.append(attempt)
+            if over_time:
+                stop_reason = "time_budget"
+                search_complete = False
+                break
+
+        winner, decision, support = select_stable_winner(
+            hit_records, config["min_stable_states"])
+        if decision != "stable_hit":
+            stop_reason = decision if stop_reason == "states_exhausted" else stop_reason
+        elif stop_reason == "states_exhausted":
+            stop_reason = "stable_hit"
+
+        public = {
+            "mode": config["mode"],
+            "attempted": True,
+            "trigger": "stage_aspect",
+            "eligible_parents": baseline["eligible_parents"],
+            "states_generated": len(states),
+            "states_total": int(getattr(states, "total", len(states))),
+            "state_space_truncated": state_space_truncated,
+            "states_visited": len(attempts),
+            "full_runs": full_runs,
+            "attempts": attempts,
+            "stable_support": support,
+            "decision": decision,
+            "stop_reason": stop_reason,
+            "search_complete": search_complete,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
+            "_winner": winner if search_complete else None,
+        }
+        if winner is not None:
+            public["winner"] = {
+                "parent_id": winner["parent_id"],
+                "state": winner["state"],
+                "box": list(winner["box_local"]),
+                "conf": winner["candidate"]["conf"],
+                "profile": winner["profile"],
+            }
+        return public
+
+    @staticmethod
+    def _public_rescue(rescue):
+        if not rescue:
+            return None
+        return {k: v for k, v in rescue.items() if not k.startswith("_")}
+
+    def _finalize_hit(self, *, context, argv, node, key_roi, caller,
+                      work_bgr, roi_tuple, params, area_range, aspect_range,
+                      gap_ratio, min_conf, outcome, candidate,
+                      effective_hsv, rescue):
+        area_min, area_max = area_range
+        asp_lo, asp_hi = aspect_range
+        result_box = candidate["result_box"]
+        conf, parts = candidate["conf"], candidate["parts"]
+        red_blob, chk = candidate["red_blob"], candidate["chk"]
+        stat = {**outcome["stat"], **self._candidate_stat(candidate)}
+        effective_params = {**params, "hsv_ranges": effective_hsv,
+                            "red_area": [area_min, area_max],
+                            "flt_aspect": [asp_lo, asp_hi],
+                            "gap_ratio": gap_ratio,
+                            "min_confidence": min_conf}
+        dbg_text = self._compose_dbg(
+            effective_params, stat, f"result: HIT box={list(result_box)}", min_conf)
+        mfaalog.info(f"[RedDotDetector] hit | box={result_box} conf={conf} {parts}")
+        print(f"[RedDotDetector] {node}\n{dbg_text}")
+
+        configured_hsv = params.get("hsv_ranges", _RED_RANGES_DEFAULT)
+        meta = {
+            "mode": "preset" if caller else "standalone",
+            "box": list(result_box), "conf": conf, "parts": parts,
+            "red_blob": red_blob, "proj": chk.get("proj"),
+            "params": {"hsv_ranges": configured_hsv,
+                       "configured_hsv_ranges": configured_hsv,
+                       "effective_hsv_ranges": effective_hsv,
+                       "red_area": [area_min, area_max],
+                       "flt_aspect": [asp_lo, asp_hi],
+                       "gap_ratio": gap_ratio,
+                       "min_conf": min_conf,
+                       "flt_hsv_rescue": params.get("flt_hsv_rescue")},
+        }
+        if rescue:
+            meta["rescue"] = rescue
+        _SAMPLER.record(
+            node=node, roi=key_roi, result="hit",
+            images={"roi_crop": work_bgr, "red_mask": outcome["red_mask"],
+                    "inner": candidate["inner"]},
+            meta=meta,
+        )
+        if caller is None:
+            self._emit_native_vision(
+                context, node, roi_tuple, argv.image, effective_hsv, area_min,
+                result_box=result_box)
+
+        detail = {
+            "result": "hit", "阶段": "打分",
+            "mode": "preset" if caller else "standalone",
+            "打分": self._score_breakdown(parts, conf, min_conf),
+            "red_area": red_blob["area"], "red_blob": red_blob,
+            "box": list(result_box), "conf": conf, "parts": parts,
+            "effective_hsv_ranges": effective_hsv, "dbg": dbg_text,
+        }
+        if rescue:
+            detail["rescue"] = rescue
+        return CustomRecognition.AnalyzeResult(box=result_box, detail=detail)
+
+    def _finalize_miss(self, *, context, argv, node, key_roi, caller,
+                       work_bgr, roi_tuple, params, hsv_ranges, area_range,
+                       aspect_range, min_conf, baseline, stage, hint, rescue):
+        area_min, area_max = area_range
+        asp_lo, asp_hi = aspect_range
+        stat = baseline["stat"]
+        effective_params = {**params, "hsv_ranges": hsv_ranges,
+                            "red_area": [area_min, area_max],
+                            "flt_aspect": [asp_lo, asp_hi],
+                            "min_confidence": min_conf}
+        dbg_text = self._compose_dbg(
+            effective_params, stat, f"result: MISS ({stage}) {hint}", min_conf)
+        dump_info = self._dump_failure(
+            node, key_roi, work_bgr, baseline["red_mask"], baseline["best_mask"])
+        miss_imgs = {"roi_crop": work_bgr, "red_mask": baseline["red_mask"]}
+        if baseline["best_mask"] is not None:
+            miss_imgs["inner"] = baseline["best_mask"]
+        best_box_local = baseline["best_box_local"]
+        meta = {
+            "mode": "preset" if caller else "standalone",
+            "box": ([best_box_local[0] + roi_tuple[0],
+                     best_box_local[1] + roi_tuple[1],
+                     best_box_local[2], best_box_local[3]]
+                    if best_box_local else None),
+            "conf": stat.get("conf"), "parts": stat.get("parts"),
+            "red_blob": stat.get("red_blob"), "proj": stat.get("proj"),
+            "gap": stat.get("gap"), "aspect_rej": stat.get("aspect_rej"),
+            "filter_stat": {
+                "red_px": stat["red_px"], "n_blobs": stat["n_blobs"],
+                "area_pass": stat["area_pass"],
+                "aspect_pass": stat.get("aspect_pass"),
+                "max_inner_px": stat["max_inner_px"], "scored": stat["scored"],
+            },
+            "params": {"hsv_ranges": hsv_ranges,
+                       "configured_hsv_ranges": hsv_ranges,
+                       "effective_hsv_ranges": hsv_ranges,
+                       "red_area": [area_min, area_max],
+                       "flt_aspect": [asp_lo, asp_hi],
+                       "gap_ratio": params.get("gap_ratio", 0.35),
+                       "min_conf": min_conf,
+                       "flt_hsv_rescue": params.get("flt_hsv_rescue")},
+            "failure_dump": dump_info,
+        }
+        if rescue:
+            meta["rescue"] = rescue
         _SAMPLER.record(
             node=node, roi=key_roi, result="miss", stage=stage,
-            images=miss_imgs,
-            meta={"mode": "preset" if caller else "standalone",
-                  "box": ([best_box_local[0] + rx, best_box_local[1] + ry,
-                           best_box_local[2], best_box_local[3]] if best_box_local else None),
-                  "conf": stat.get("conf"), "parts": stat.get("parts"),
-                  "red_blob": stat.get("red_blob"), "proj": stat.get("proj"),
-                  "gap": stat.get("gap"), "aspect_rej": stat.get("aspect_rej"),
-                  "filter_stat": {"red_px": stat["red_px"], "n_blobs": stat["n_blobs"],
-                                  "area_pass": stat["area_pass"],
-                                  "aspect_pass": stat.get("aspect_pass"),
-                                  "max_inner_px": stat["max_inner_px"], "scored": stat["scored"]},
-                  "params": {"hsv_ranges": hsv_ranges,
-                             "red_area": [area_min, area_max],
-                             "min_conf": min_conf}})
-        # 非预设：本级持有整屏，直接做原生回显；预设模式由 _run_preset 在整屏上回显
+            images=miss_imgs, meta=meta,
+        )
         if caller is None:
-            self._emit_native_vision(context, node, (rx, ry, rw, rh),
-                                     argv.image, hsv_ranges, area_min)
-        return self._miss("standalone", stage, hint, stat, params, dbg_text, min_conf)
+            self._emit_native_vision(
+                context, node, roi_tuple, argv.image, hsv_ranges, area_min)
+        extra = {"failure_dump": dump_info}
+        if rescue:
+            extra["rescue"] = rescue
+        return self._miss(
+            "preset" if caller else "standalone", stage, hint, stat, effective_params,
+            dbg_text, min_conf, extra=extra)
 
     # ------------------------------------------------------------------
     # 感叹号结构检测：返回投影 + 断层诊断信息
@@ -1063,7 +1429,7 @@ class RedDotDetector(CustomRecognition):
         if stat.get("aspect_pass", 0) == 0:
             return "aspect", (f"红块 h/w 都不在 flt_aspect 内(被拒 {stat.get('aspect_rej')})；"
                               "横条/竖柱杂红属正常拒；若是连片真货被误杀，"
-                              "优先收紧 flt_red_hsv 拆开连片，其次放宽 flt_aspect")
+                              "由 flt_hsv_rescue 严格 HSV 搜索拆开连片；不要放宽 flt_aspect")
         if stat["max_inner_px"] == 0:
             return "interior", "红块内无封闭非红区(无感叹号轮廓)：roi 偏移 / 红圈破损 / 被模糊填满"
         return "confidence", (f"最高置信 {stat.get('conf')} < min_confidence({min_conf})；"
@@ -1071,7 +1437,7 @@ class RedDotDetector(CustomRecognition):
                               f"或检查偏白/竖向是否被模糊吃掉")
 
     def _miss(self, mode: str, stage: str, hint: str, stat: dict, params: dict,
-              dbg_text: str = None, min_conf=None):
+              dbg_text: str = None, min_conf=None, extra: dict = None):
         """
         统一失败出口（金字塔回调）：
           第1层 result=miss；第2层 阶段=筛选/打分；
@@ -1092,6 +1458,8 @@ class RedDotDetector(CustomRecognition):
                         "内部像素": stat.get("max_inner_px"), "打分数": stat.get("scored")},
                 "stat": stat, "dbg": dbg_text,
             }
+        if extra:
+            detail.update(extra)
         mfaalog.warning(f"[RedDotDetector] miss@{stage} | {hint}")
         print(f"[RedDotDetector] miss\n{dbg_text}" if dbg_text else f"[RedDotDetector] miss stat={stat}")
         return CustomRecognition.AnalyzeResult(box=None, detail=detail)
@@ -1127,7 +1495,8 @@ class RedDotDetector(CustomRecognition):
     # ------------------------------------------------------------------
 
     def _emit_native_vision(self, context: Context, node: str, roi_tuple,
-                            image: np.ndarray, hsv_ranges: list, area_min) -> None:
+                            image: np.ndarray, hsv_ranges: list, area_min,
+                            result_box=None) -> None:
         """
         在整屏原图上跑一次内置 ColorMatch(method 40，同 hsv_ranges)，由框架原生画图：
         绿框=ROI，红字 R:[box]=红色 blob 包围框(与本识别器返回的 box 是同一个红块)。
@@ -1145,7 +1514,8 @@ class RedDotDetector(CustomRecognition):
             context.run_recognition(echo, image, pipeline_override={
                 echo: {
                     "recognition": "ColorMatch",
-                    "roi": list(roi_tuple),
+                    # 命中时限制到实际返回框，避免大 ROI 内 ColorMatch 画出另一个更大红块。
+                    "roi": list(result_box if result_box is not None else roi_tuple),
                     "method": 40,   # HSV，与 hsv_ranges 同为 OpenCV 坐标系(H 0-180)
                     "lower": lowers,
                     "upper": uppers,
@@ -1204,7 +1574,7 @@ class RedDotDetector(CustomRecognition):
             last_map = self._last_dump = {}
         now = time.time()
         if now - last_map.get(key, 0.0) < _DUMP_MIN_INTERVAL:
-            return
+            return {"status": "throttled", "files": []}
         last_map[key] = now
 
         saved = []
@@ -1218,3 +1588,5 @@ class RedDotDetector(CustomRecognition):
                 saved.append(p)
         if saved:
             print(f"[RedDotDetector] 失败截图 -> {saved}")  # 仅入 txt 日志，不上 UI
+            return {"status": "saved", "files": saved}
+        return {"status": "failed", "files": []}

--- a/agent/recognition/binarymatch.py
+++ b/agent/recognition/binarymatch.py
@@ -16,12 +16,16 @@ from maa.define import RectType
 from utils import mfaalog
 from .rdd_sampler import RddSampler
 from .rdd_hsv_rescue import (
-    build_topology_states,
+    DIRECTIONS,
+    boxes_agree,
+    channel_cutpoints,
+    direction_deltas,
     is_strict_mask,
     lineage_parent,
-    mask_digest,
+    neighbor_states,
     normalize_rescue_config,
     select_stable_winner,
+    sort_parents,
     strict_profile,
 )
 
@@ -595,6 +599,45 @@ _RED_RANGES_DEFAULT = [
 # 定标依据见 docs/RedDotDetector_打分模型.md §15。
 _FLT_ASPECT_DEFAULT = [0.6, 1.6]
 
+# 被长宽比闸拒绝的红块，几何最多留几条进 detail/sampler。仅观测容量，不参与判定。
+# 放开到 12（原 3）是为了给"大 ROI 里父块会不会爆"提供分布数据：
+# 实测 boss-adb 一帧就有 5 个被拒块，只有 1 个是真红点，旧上限看不出这个比例。
+# 总数另记 aspect_rej_n，不受此上限影响。
+_ASPECT_REJ_KEEP = 12
+
+# 救援局部重跑窗口在父块外接框四周留的余量(像素)。父块本就完整落在自己的外接框内，
+# 理论上 0 亦可；留 2 是防边界效应的保险，实测 0 与 2 结果无差异，成本可忽略。
+_RESCUE_PAD = 2
+
+# select_stable_winner 的判定码 → 回传用中文，与金字塔风格一致。
+_RESCUE_DECISION_CN = {
+    "stable_hit": "稳定命中",
+    "no_hit": "未命中",
+    "unstable_hit": "命中不稳定",
+    "ambiguous_split": "同档多解",
+    "ambiguous_stable_hits": "多解歧义",
+    "error": "异常",
+}
+# GUI 日志栏用的一句话失败摘要。完整 hint(含 aspect_rej 明细、调参方向)长达数百字，
+# 只进 print 与 detail；日志栏刷全文既挤占用户视野，也容易让人漏看后面的救援结论。
+_MISS_BRIEF = {
+    "red_mask": "HSV 没框到红色",
+    "area": "红块面积不在闸内",
+    "aspect": "红块长宽比出圈(疑连片)",
+    "interior": "红块内无封闭白芯",
+    "confidence": "打分不足",
+}
+
+# 每种不成立各自的调参方向；成立时的说明由 _rescue_hint 现算。
+_RESCUE_HINT_CN = {
+    "no_hit": "三个切法都没从该父块切出合格红点；看 尝试[].卡在 —— "
+              "aspect=切得不够狠，interior/red_mask/area=切过头",
+    "unstable_hit": "只有单档命中、相邻档不复现；切点疑似落在悬崖边，不予采纳",
+    "ambiguous_split": "同一档内该父块切出多个候选，无法认定唯一后代",
+    "ambiguous_stable_hits": "出现多个互不相邻的稳定解，按 fail closed 一律拒绝",
+    "error": "救援内部异常，已保持 baseline 结果",
+}
+
 # ── 打分权重 sc_w_*（v2）─────────────────────────────────────────────
 # 设计依据见 docs/RedDotDetector_打分模型.md（真假样本论证）。核心两条：
 #   1) 竖长(高瘦) + 偏白(白芯) 抗模糊、是真正的判别金线，并列为主，各 0.45；
@@ -864,27 +907,39 @@ class RedDotDetector(CustomRecognition):
                 )
             except Exception:
                 rescue = {
-                    "mode": rescue_cfg["mode"], "attempted": True,
-                    "trigger": "stage_aspect", "decision": "error",
-                    "stop_reason": "exception",
-                    "error": traceback.format_exc().strip().splitlines()[-1],
+                    "模式": rescue_cfg["mode"], "结论": _RESCUE_DECISION_CN["error"],
+                    "说明": _RESCUE_HINT_CN["error"], "停因": "异常",
+                    "_decision": "error", "_winner": None,
+                    "错误": traceback.format_exc().strip().splitlines()[-1],
                 }
                 print(f"[RedDotDetector] HSV 救援异常，保持 baseline miss:\n"
                       f"{traceback.format_exc()}")
+            self._log_rescue(node, rescue)
             winner = rescue.get("_winner")
             if (winner is not None and rescue_cfg["mode"] == "active"
-                    and rescue.get("search_complete")
-                    and rescue.get("decision") == "stable_hit"):
-                return self._finalize_hit(
-                    context=context, argv=argv, node=node, key_roi=key_roi,
-                    caller=caller, work_bgr=work_bgr, roi_tuple=(rx, ry, rw, rh),
-                    params=params, area_range=(area_min, area_max),
+                    and rescue.get("_decision") == "stable_hit"):
+                confirmed = self._rescue_confirm_full(
+                    hsv_np=hsv_np, winner=winner,
+                    area_range=(area_min, area_max),
                     aspect_range=(asp_lo, asp_hi), gap_ratio=gap_ratio,
-                    min_conf=min_conf, outcome=winner["outcome"],
-                    candidate=winner["candidate"],
-                    effective_hsv=winner["profile"],
-                    rescue=self._public_rescue(rescue),
-                )
+                    min_conf=min_conf, rx=rx, ry=ry)
+                if confirmed is None:
+                    rescue["停因"] = "全区复核不一致"
+                    rescue["说明"] = "局部结论未能在整幅 ROI 复现，已 fail closed"
+                    print(f"[RedDotDetector] 救援 {node} | 全区复核不一致，维持 miss")
+                else:
+                    outcome_full, candidate_full = confirmed
+                    return self._finalize_hit(
+                        context=context, argv=argv, node=node, key_roi=key_roi,
+                        caller=caller, work_bgr=work_bgr,
+                        roi_tuple=(rx, ry, rw, rh),
+                        params=params, area_range=(area_min, area_max),
+                        aspect_range=(asp_lo, asp_hi), gap_ratio=gap_ratio,
+                        min_conf=min_conf, outcome=outcome_full,
+                        candidate=candidate_full,
+                        effective_hsv=winner["profile"],
+                        rescue=self._public_rescue(rescue),
+                    )
 
         return self._finalize_miss(
             context=context, argv=argv, node=node, key_roi=key_roi,
@@ -930,8 +985,10 @@ class RedDotDetector(CustomRecognition):
                         "fill": round(area / max(bw * bh, 1), 2)}
             if not (asp_lo <= aspect <= asp_hi):
                 eligible_parents.append(geometry)
-                if len(stat.setdefault("aspect_rej", [])) < 3:
-                    stat["aspect_rej"].append(
+                stat["aspect_rej_n"] = stat.get("aspect_rej_n", 0) + 1
+                rej = stat.setdefault("aspect_rej", [])
+                if len(rej) < _ASPECT_REJ_KEEP:
+                    rej.append(
                         {k: geometry[k] for k in ("w", "h", "area", "aspect", "fill")})
                 continue
             stat["aspect_pass"] += 1
@@ -1016,152 +1073,285 @@ class RedDotDetector(CustomRecognition):
                     "has_below": chk.get("has_below")},
         }
 
-    def _preview_rescue(self, labeled, baseline_labels, eligible_ids,
-                        area_min, area_max, asp_lo, asp_hi):
-        """只做 area/aspect/lineage，避免对无望 profile 完整打分。"""
-        feasible = []
-        n_blobs = int(labeled.max()) if labeled.size else 0
-        for i in range(1, n_blobs + 1):
-            blob = (labeled == i)
-            area = int(blob.sum())
-            if not (area_min <= area <= area_max):
+    def _rescue_try(self, *, hsv_np, baseline, geo, delta_s, delta_v,
+                    hsv_ranges, area_range, aspect_range, gap_ratio,
+                    min_conf, rx, ry):
+        """在**父块外接框**内跑一次完整检测链，返回 (候选, 卡在, 红像素数)。
+
+        只在局部重跑而非整个 ROI：救援的判定被 lineage 限定在这一个父块内，
+        框选区其余像素怎么变都与结论无关。实测 23 处对比与全区重跑逐位一致，
+        平均提速 5.8 倍，且成本随父块（受面积闸约束 ≤ area_max）而非 ROI 增长。
+        """
+        profile = strict_profile(hsv_ranges, delta_s, delta_v)
+        if profile is None:
+            return None, "参数", 0
+
+        h, w = hsv_np.shape[:2]
+        x0 = max(0, int(geo["x"]) - _RESCUE_PAD)
+        y0 = max(0, int(geo["y"]) - _RESCUE_PAD)
+        x1 = min(w, int(geo["x"]) + int(geo["w"]) + _RESCUE_PAD)
+        y1 = min(h, int(geo["y"]) + int(geo["h"]) + _RESCUE_PAD)
+        if x1 <= x0 or y1 <= y0:
+            return None, "窗口", 0
+
+        sub_hsv = hsv_np[y0:y1, x0:x1]
+        sub_base_mask = baseline["red_mask"][y0:y1, x0:x1]
+        sub_base_lab = baseline["labeled"][y0:y1, x0:x1]
+
+        out = self._detect_once(
+            sub_hsv, profile, area_range[0], area_range[1],
+            aspect_range[0], aspect_range[1], gap_ratio, min_conf,
+            rx + x0, ry + y0, collect_all=True,
+        )
+        red_px = int(out["stat"]["red_px"])
+        # 严格子集：只许删红像素，不许凭空添红。
+        if not is_strict_mask(out["red_mask"], sub_base_mask):
+            return None, "子集", red_px
+
+        for cand in out["candidates"]:
+            if lineage_parent(cand["blob_mask"], sub_base_lab,
+                              [geo["label"]]) != geo["label"]:
                 continue
-            ys, xs = np.where(blob)
-            bw, bh = int(xs.max() - xs.min() + 1), int(ys.max() - ys.min() + 1)
-            aspect = round(bh / max(bw, 1), 2)
-            if not (asp_lo <= aspect <= asp_hi):
-                continue
-            parent_id = lineage_parent(blob, baseline_labels, eligible_ids)
-            if parent_id is not None:
-                feasible.append({"label": i, "parent_id": parent_id})
-        return feasible
+            bx, by, bw, bh = cand["box_local"]
+            cand["box_local"] = (bx + x0, by + y0, bw, bh)   # 换回 ROI 坐标系
+            cand["profile"] = profile
+            return cand, None, red_px
+
+        # 没有血统合格的候选：借 baseline 同一套诊断词表说明卡在哪步，
+        # 好让 aspect(切得不够狠) 与 interior/red_mask(切过头) 一眼可分。
+        if out["candidates"]:
+            return None, "血统", red_px
+        stage, _ = self._diagnose(out["stat"], area_range[0], area_range[1], min_conf)
+        return None, stage, red_px
 
     def _run_hsv_rescue(self, *, hsv_np, baseline, hsv_ranges, area_range,
                         aspect_range, gap_ratio, min_conf, rx, ry, config):
-        """受约束的严格 HSV 拓扑断点搜索；返回内部 winner 与可序列化轨迹。"""
+        """严格 HSV 救援：切点由父块自身分布算出，局部重跑，跨档复现验收。
+
+        流程（每个被长宽比闸拒的父块，按"像不像红点"排序后依次处理）：
+          1. 取该父块像素，两个通道各做一次直方图 → Otsu 切点（微秒级）
+          2. 三个切法(只切亮度/只切饱和/双切)各跑一次**主档**
+          3. 命中位置一致 → 取增量最小的切法；位置分散 → 判方向歧义，拒绝
+          4. 对选中切法补跑上下**陪跑档**，交 select_stable_winner 判跨档稳定
+        任一环节失败即换下一个父块；预算耗尽维持 baseline miss。
+        """
         started = time.perf_counter()
-        area_min, area_max = area_range
-        asp_lo, asp_hi = aspect_range
-        eligible_ids = [item["label"] for item in baseline["eligible_parents"]]
-        eligible_mask = np.isin(baseline["labeled"], eligible_ids)
-        states = build_topology_states(hsv_np, eligible_mask, hsv_ranges, config)
-        seen_masks, attempts, hit_records = set(), [], []
-        state_space_truncated = bool(getattr(states, "truncated", False))
+        budget_ms = config["time_budget_ms"]
+
+        def timed_out():
+            return (time.perf_counter() - started) * 1000 >= budget_ms
+
+        def elapsed():
+            return round((time.perf_counter() - started) * 1000, 2)
+
+        parents = sort_parents(baseline["eligible_parents"])
+        parent_rows, attempts = [], []
         full_runs = 0
-        stop_reason = "state_budget" if state_space_truncated else "states_exhausted"
-        search_complete = not state_space_truncated
+        tried_parents = 0
+        winner = decision = support = None
+        cutpoints = win_direction = win_main = None
+        stop_reason = "父块用尽"
 
-        for state in states:
-            elapsed_ms = (time.perf_counter() - started) * 1000
-            if elapsed_ms >= config["time_budget_ms"]:
-                stop_reason = "time_budget"
-                search_complete = False
-                break
-            profile = strict_profile(
-                hsv_ranges, state["delta_s"], state["delta_v"])
-            if profile is None:
+        for geo in parents:
+            row = {"序": len(parent_rows) + 1,
+                   "几何": f"{geo['w']}x{geo['h']}", "面积": geo["area"],
+                   "长宽比": geo["aspect"], "填充": geo["fill"], "试了": False}
+            parent_rows.append(row)
+            if winner is not None:
                 continue
-            red_mask = _compute_hsv_mask(hsv_np, profile)
-            if (time.perf_counter() - started) * 1000 >= config["time_budget_ms"]:
-                stop_reason = "time_budget"
-                search_complete = False
-                break
-            if not is_strict_mask(red_mask, baseline["red_mask"]):
+            if tried_parents >= config["max_parents"]:
+                row["跳过"] = "父块预算"
                 continue
-            digest = mask_digest(red_mask)
-            if digest in seen_masks:
+            if timed_out():
+                row["跳过"] = "超时"
+                stop_reason = "超时"
                 continue
-            seen_masks.add(digest)
-            labeled, n_blobs = _label_blobs(red_mask)
-            if (time.perf_counter() - started) * 1000 >= config["time_budget_ms"]:
-                stop_reason = "time_budget"
-                search_complete = False
-                break
-            feasible = self._preview_rescue(
-                labeled, baseline["labeled"], eligible_ids,
-                area_min, area_max, asp_lo, asp_hi,
-            )
-            attempt = {
-                "state": dict(state), "red_px": int(red_mask.sum()),
-                "n_blobs": int(n_blobs), "feasible": len(feasible),
-                "full_run": False, "hits": [],
-            }
-            if not feasible:
-                attempts.append(attempt)
-                continue
-            if full_runs >= config["max_full_runs"]:
-                stop_reason = "full_run_budget"
-                search_complete = False
-                attempts.append(attempt)
-                break
 
-            outcome = self._detect_once(
-                hsv_np, profile, area_min, area_max, asp_lo, asp_hi,
-                gap_ratio, min_conf, rx, ry,
-                red_mask=red_mask, labeled=labeled, collect_all=True,
-            )
-            full_runs += 1
-            attempt["full_run"] = True
-            over_time = ((time.perf_counter() - started) * 1000
-                         >= config["time_budget_ms"])
-            for candidate in outcome["candidates"]:
-                parent_id = lineage_parent(
-                    candidate["blob_mask"], baseline["labeled"], eligible_ids)
-                if parent_id is None:
+            pixels = hsv_np[baseline["labeled"] == geo["label"]]
+            cuts = channel_cutpoints(pixels, hsv_ranges, config)
+            if cuts is None:
+                row["跳过"] = "无法定点"
+                continue
+            tried_parents += 1
+            row["试了"] = True
+
+            # —— 第 2 步：三个切法各跑一次主档 ——
+            probes, seen_deltas = {}, set()
+            for direction in DIRECTIONS:
+                if timed_out():
+                    stop_reason = "超时"
+                    break
+                if full_runs >= config["max_full_runs"]:
+                    stop_reason = "重跑预算"
+                    break
+                pair = direction_deltas(cuts, direction)
+                if pair is None or pair in seen_deltas:
+                    continue          # 例如某通道增量为 0 时，双切与单切等价
+                seen_deltas.add(pair)
+                cand, blocked, red_px = self._rescue_try(
+                    hsv_np=hsv_np, baseline=baseline, geo=geo,
+                    delta_s=pair[0], delta_v=pair[1], hsv_ranges=hsv_ranges,
+                    area_range=area_range, aspect_range=aspect_range,
+                    gap_ratio=gap_ratio, min_conf=min_conf, rx=rx, ry=ry)
+                full_runs += 1
+                attempts.append(self._rescue_attempt(
+                    row["序"], direction, pair, red_px, blocked, cand))
+                if cand is not None:
+                    probes[direction] = (pair, cand)
+
+            if not probes:
+                continue
+            # —— 第 3 步：不同切法必须指向同一处，否则是真歧义 ——
+            if not boxes_agree([c["box_local"] for _, c in probes.values()]):
+                row["跳过"] = "方向歧义"
+                stop_reason = "方向歧义"
+                continue
+
+            win_direction = min(probes, key=lambda d: sum(probes[d][0]))
+            (ds, dv), main_cand = probes[win_direction]
+
+            # —— 第 4 步：补跑陪跑档，交既有的跨档稳定判定 ——
+            records = []
+            for state in neighbor_states(win_direction, ds, dv, config):
+                is_main = (state["delta_s"], state["delta_v"]) == (ds, dv)
+                cand = main_cand if is_main else None
+                if cand is None:
+                    if timed_out():
+                        stop_reason = "超时"
+                        break
+                    if full_runs >= config["max_full_runs"]:
+                        stop_reason = "重跑预算"
+                        break
+                    cand, blocked, red_px = self._rescue_try(
+                        hsv_np=hsv_np, baseline=baseline, geo=geo,
+                        delta_s=state["delta_s"], delta_v=state["delta_v"],
+                        hsv_ranges=hsv_ranges, area_range=area_range,
+                        aspect_range=aspect_range, gap_ratio=gap_ratio,
+                        min_conf=min_conf, rx=rx, ry=ry)
+                    full_runs += 1
+                    attempts.append(self._rescue_attempt(
+                        row["序"], win_direction + "·陪跑",
+                        (state["delta_s"], state["delta_v"]),
+                        red_px, blocked, cand))
+                if cand is None:
                     continue
-                record = {
-                    "state": dict(state), "parent_id": parent_id,
-                    "box_local": candidate["box_local"],
-                    "scan_index": candidate["scan_index"],
-                    "candidate": candidate, "outcome": outcome,
-                    "profile": profile,
-                }
-                hit_records.append(record)
-                attempt["hits"].append({
-                    "parent_id": parent_id,
-                    "box": list(candidate["box_local"]),
-                    "conf": candidate["conf"],
+                records.append({
+                    "state": state, "parent_id": geo["label"],
+                    "box_local": cand["box_local"],
+                    "scan_index": cand["scan_index"],
+                    "candidate": cand, "profile": cand["profile"],
                 })
-            attempts.append(attempt)
-            if over_time:
-                stop_reason = "time_budget"
-                search_complete = False
-                break
 
-        winner, decision, support = select_stable_winner(
-            hit_records, config["min_stable_states"])
-        if decision != "stable_hit":
-            stop_reason = decision if stop_reason == "states_exhausted" else stop_reason
-        elif stop_reason == "states_exhausted":
-            stop_reason = "stable_hit"
+            cand_winner, cand_decision, cand_support = select_stable_winner(
+                records, config["min_stable_states"])
+            decision, support = cand_decision, cand_support
+            cutpoints = cuts
+            if cand_decision == "stable_hit":
+                winner = cand_winner
+                win_main = (ds, dv)
+                stop_reason = "稳定命中"
+            else:
+                row["跳过"] = cand_decision
 
+        if decision is None:
+            decision = "no_hit"
         public = {
-            "mode": config["mode"],
-            "attempted": True,
-            "trigger": "stage_aspect",
-            "eligible_parents": baseline["eligible_parents"],
-            "states_generated": len(states),
-            "states_total": int(getattr(states, "total", len(states))),
-            "state_space_truncated": state_space_truncated,
-            "states_visited": len(attempts),
-            "full_runs": full_runs,
-            "attempts": attempts,
-            "stable_support": support,
-            "decision": decision,
-            "stop_reason": stop_reason,
-            "search_complete": search_complete,
-            "elapsed_ms": round((time.perf_counter() - started) * 1000, 2),
-            "_winner": winner if search_complete else None,
+            "模式": config["mode"],
+            "结论": _RESCUE_DECISION_CN.get(decision, decision),
+            "说明": self._rescue_hint(decision, win_direction, cutpoints,
+                                      winner, support),
+            "耗时ms": elapsed(),
+            "切点": cutpoints,
+            "尝试": attempts,
+            "父块": {"总数": len(parents), "已试": tried_parents,
+                     "跳过": len(parents) - tried_parents, "明细": parent_rows},
+            "预算": {"重跑": full_runs, "上限": config["max_full_runs"],
+                     "耗时ms": elapsed(), "上限ms": budget_ms},
+            "停因": stop_reason,
+            "_decision": decision,
+            "_winner": winner,
         }
         if winner is not None:
-            public["winner"] = {
-                "parent_id": winner["parent_id"],
-                "state": winner["state"],
-                "box": list(winner["box_local"]),
-                "conf": winner["candidate"]["conf"],
-                "profile": winner["profile"],
+            public["胜出"] = {
+                "方向": win_direction,
+                # 主档 = 切点直接算出的那一档；采纳档 = 复现组里最保守(增量最小)的一档。
+                # 两者可以不同，这不是矛盾：切点定位置，复现组决定最终取哪一档。
+                "主档增量": list(win_main) if win_main else None,
+                "采纳增量": [winner["state"]["delta_s"],
+                             winner["state"]["delta_v"]],
+                "框": list(winner["box_local"]),
+                "分": winner["candidate"]["conf"],
+                "复现": len(support[0]["states"]) if support else 0,
             }
         return public
+
+    @staticmethod
+    def _rescue_attempt(parent_no, direction, pair, red_px, blocked, cand):
+        """一条尝试记录。失败档不带 框/分（恒为空），省体积也少一层噪声。"""
+        row = {"父块": parent_no, "方向": direction,
+               "增量": [int(pair[0]), int(pair[1])], "红像素": int(red_px),
+               "卡在": blocked}
+        if cand is not None:
+            row["框"] = list(cand["box_local"])
+            row["分"] = cand["conf"]
+        return row
+
+    @staticmethod
+    def _rescue_hint(decision, direction, cutpoints, winner, support):
+        """一句话说清这次救援凭什么成立 / 因何不成立，措辞与调参方向对齐。"""
+        if decision == "stable_hit" and winner is not None:
+            ds, dv = winner["state"]["delta_s"], winner["state"]["delta_v"]
+            base = []
+            if cutpoints:
+                if dv > 0:
+                    base.append(f"亮度切点{cutpoints['亮度']['Otsu']}"
+                                f"(基线{cutpoints['亮度']['基线']})")
+                if ds > 0:
+                    base.append(f"饱和切点{cutpoints['饱和']['Otsu']}"
+                                f"(基线{cutpoints['饱和']['基线']})")
+            times = len(support[0]["states"]) if support else 0
+            return (f"切法{direction}；{'；'.join(base)}；"
+                    f"相邻{times}档复现同框，采纳最保守档 ΔS{ds}/ΔV{dv}；血统同源")
+        return _RESCUE_HINT_CN.get(decision, f"未成立({decision})")
+
+    @staticmethod
+    def _log_rescue(node, rescue):
+        """救援只走 print 单行摘要：ΔS/ΔV、lineage 等细节留在 detail.救援 里，
+        由框架随 reco_details 落进 maa 核心日志，不占 GUI 日志栏（见观测契约）。"""
+        if not rescue:
+            return
+        budget = rescue.get("预算") or {}
+        head = f"[RedDotDetector] 救援 {node} | {rescue.get('结论')}"
+        win = rescue.get("胜出")
+        if win:
+            tail = (f"{win['方向']}ΔS{win['采纳增量'][0]}/ΔV{win['采纳增量'][1]} "
+                    f"复现{win['复现']}档 → box={win['框']} 分{win['分']}")
+        else:
+            blocked = [a.get("卡在") for a in (rescue.get("尝试") or [])
+                       if a.get("卡在")]
+            uniq = sorted(set(blocked))
+            tail = f"停因={rescue.get('停因')}" + (f" 卡在={','.join(uniq)}" if uniq else "")
+        print(f"{head} | {tail} | {budget.get('重跑', 0)}重跑 "
+              f"{rescue.get('耗时ms', 0)}ms")
+
+    def _rescue_confirm_full(self, *, hsv_np, winner, area_range, aspect_range,
+                             gap_ratio, min_conf, rx, ry):
+        """active 改判前，用胜出参数在**整个 ROI** 复跑一次。
+
+        两个作用：① 取回整幅红掩膜，供 sampler / 原生回显落盘（局部窗口的掩膜尺寸对不上）；
+        ② 作为局部结论的最后一道交叉校验 —— 全区跑不出同一个框就 fail closed。
+        只在 active 且已有稳定解时执行，属低频路径。
+        """
+        outcome = self._detect_once(
+            hsv_np, winner["profile"], area_range[0], area_range[1],
+            aspect_range[0], aspect_range[1], gap_ratio, min_conf, rx, ry,
+            collect_all=True,
+        )
+        target = tuple(winner["box_local"])
+        for cand in outcome["candidates"]:
+            if tuple(cand["box_local"]) == target:
+                return outcome, cand
+        return None
 
     @staticmethod
     def _public_rescue(rescue):
@@ -1204,7 +1394,7 @@ class RedDotDetector(CustomRecognition):
                        "flt_hsv_rescue": params.get("flt_hsv_rescue")},
         }
         if rescue:
-            meta["rescue"] = rescue
+            meta["救援"] = rescue
         _SAMPLER.record(
             node=node, roi=key_roi, result="hit",
             images={"roi_crop": work_bgr, "red_mask": outcome["red_mask"],
@@ -1225,7 +1415,7 @@ class RedDotDetector(CustomRecognition):
             "effective_hsv_ranges": effective_hsv, "dbg": dbg_text,
         }
         if rescue:
-            detail["rescue"] = rescue
+            detail["救援"] = rescue
         return CustomRecognition.AnalyzeResult(box=result_box, detail=detail)
 
     def _finalize_miss(self, *, context, argv, node, key_roi, caller,
@@ -1255,10 +1445,12 @@ class RedDotDetector(CustomRecognition):
             "conf": stat.get("conf"), "parts": stat.get("parts"),
             "red_blob": stat.get("red_blob"), "proj": stat.get("proj"),
             "gap": stat.get("gap"), "aspect_rej": stat.get("aspect_rej"),
+            "aspect_rej_n": stat.get("aspect_rej_n"),
             "filter_stat": {
                 "red_px": stat["red_px"], "n_blobs": stat["n_blobs"],
                 "area_pass": stat["area_pass"],
                 "aspect_pass": stat.get("aspect_pass"),
+                "aspect_rej_n": stat.get("aspect_rej_n", 0),
                 "max_inner_px": stat["max_inner_px"], "scored": stat["scored"],
             },
             "params": {"hsv_ranges": hsv_ranges,
@@ -1272,7 +1464,7 @@ class RedDotDetector(CustomRecognition):
             "failure_dump": dump_info,
         }
         if rescue:
-            meta["rescue"] = rescue
+            meta["救援"] = rescue
         _SAMPLER.record(
             node=node, roi=key_roi, result="miss", stage=stage,
             images=miss_imgs, meta=meta,
@@ -1282,7 +1474,7 @@ class RedDotDetector(CustomRecognition):
                 context, node, roi_tuple, argv.image, hsv_ranges, area_min)
         extra = {"failure_dump": dump_info}
         if rescue:
-            extra["rescue"] = rescue
+            extra["救援"] = rescue
         return self._miss(
             "preset" if caller else "standalone", stage, hint, stat, effective_params,
             dbg_text, min_conf, extra=extra)
@@ -1427,8 +1619,10 @@ class RedDotDetector(CustomRecognition):
         if stat["area_pass"] == 0:
             return "area", f"红色面积都不在 [{area_min},{area_max}]，调 red_area（多半是 min 太大）"
         if stat.get("aspect_pass", 0) == 0:
-            return "aspect", (f"红块 h/w 都不在 flt_aspect 内(被拒 {stat.get('aspect_rej')})；"
-                              "横条/竖柱杂红属正常拒；若是连片真货被误杀，"
+            rej = stat.get("aspect_rej") or []
+            total = stat.get("aspect_rej_n", len(rej))
+            return "aspect", (f"红块 h/w 都不在 flt_aspect 内(被拒 {total} 块，"
+                              f"前 3: {rej[:3]})；横条/竖柱杂红属正常拒；若是连片真货被误杀，"
                               "由 flt_hsv_rescue 严格 HSV 搜索拆开连片；不要放宽 flt_aspect")
         if stat["max_inner_px"] == 0:
             return "interior", "红块内无封闭非红区(无感叹号轮廓)：roi 偏移 / 红圈破损 / 被模糊填满"
@@ -1460,7 +1654,18 @@ class RedDotDetector(CustomRecognition):
             }
         if extra:
             detail.update(extra)
-        mfaalog.warning(f"[RedDotDetector] miss@{stage} | {hint}")
+        # 救援已找到稳定解却仍 miss，只可能是 shadow 不改判 —— 必须在日志栏说明白，
+        # 否则用户看到的就只是一条 miss，会误判成救援没工作。
+        rescue = (extra or {}).get("救援") or {}
+        tail = ""
+        if rescue.get("结论") == "稳定命中":
+            win = rescue.get("胜出") or {}
+            tail = (f"｜严格HSV救援已找到稳定解 box={win.get('框')} 分{win.get('分')}"
+                    f"，当前 mode={rescue.get('模式')} 不改判")
+        elif rescue.get("attempted") or rescue.get("尝试"):
+            tail = f"｜救援未成立({rescue.get('结论')})"
+        mfaalog.warning(f"[RedDotDetector] miss@{stage} | "
+                        f"{_MISS_BRIEF.get(stage, stage)}{tail}")
         print(f"[RedDotDetector] miss\n{dbg_text}" if dbg_text else f"[RedDotDetector] miss stat={stat}")
         return CustomRecognition.AnalyzeResult(box=None, detail=detail)
 
@@ -1549,7 +1754,11 @@ class RedDotDetector(CustomRecognition):
             f"inner_px={stat.get('max_inner_px')} scored={stat.get('scored')}",
         ]
         if stat.get("aspect_rej"):
-            lines.append(f"aspect_rej: {stat['aspect_rej']}")
+            rej = stat["aspect_rej"]
+            total = stat.get("aspect_rej_n", len(rej))
+            shown = rej[:3]
+            tail = f" ...(共{total})" if total > len(shown) else ""
+            lines.append(f"aspect_rej: {shown}{tail}")
         if stat.get("red_blob"):
             rb = stat["red_blob"]
             lines.append(f"red_blob: {rb['w']}x{rb['h']} area={rb['area']} "

--- a/agent/recognition/binarymatch.py
+++ b/agent/recognition/binarymatch.py
@@ -406,7 +406,8 @@ class HSVShapeMatching(CustomRecognition):
 #
 #   样本采集(语料即回归集，见 rdd_sampler.py)：命中/未命中都把小图 + 完整识别信息
 #     (conf 四项分解/proj/红块 aspect·fill/生效参数)落成累积语料：
-#     <log_dir>/RedDotDetector_samples/ 下唯一命名小图 + samples.jsonl(一行一事件)。
+#     <log_dir>/RedDotDetector_samples/ 下唯一命名小图 + samples.jsonl.log(一行一事件，
+#     .log 后缀是为了能被 UI"导出日志"收走，理由见 rdd_sampler.py 头注)。
 #     整个文件夹拿走即可离线回放定标(v3)。RDD_SAMPLE=off/fail/all(默认 all，env 穿透
 #     运行侧配置)；RDD_SAMPLE_DIR 指定落盘目录(VSCode 调试 log_dir 被重定向时用)；
 #     同检测点默认 1800s 采一张(RDD_SAMPLE_INTERVAL 可调)+ 画面不变去重。

--- a/agent/recognition/rdd_hsv_rescue.py
+++ b/agent/recognition/rdd_hsv_rescue.py
@@ -1,8 +1,14 @@
 """RedDotDetector 严格 HSV 救援的纯算法工具。
 
 本模块不依赖 MaaFramework，也不负责识别副作用。它只处理：
-参数校验、严格 HSV profile、拓扑事件状态、父子 lineage 与跨状态稳定选择。
+参数校验、严格 HSV profile、切点计算、父块排序、父子 lineage 与跨档稳定选择。
 运行时和离线回放共用这里，避免出现两套救援算法。
+
+设计要点见 doc/agent/RedDotDetector/RedDotDetector_v3救援实施计划.md：
+  · 切点由被卡住的父块自身颜色分布**算出**（Otsu），不枚举参数空间；
+  · 亮度/饱和度两个维度都保留，三个方向（只切亮度/只切饱和/双切）先各跑一次主档，
+    位置一致才选增量最小者补跑陪跑档 —— 避免三组各自成稳定分量而互判歧义；
+  · 代码中不得出现来自样本的阈值常数，max_delta_* 只作安全护栏，不是工作点。
 """
 
 from __future__ import annotations
@@ -16,24 +22,31 @@ import numpy as np
 
 DEFAULT_RESCUE_CONFIG: Dict[str, Any] = {
     "mode": "off",
-    "max_delta_s": 48,
-    "max_delta_v": 64,
-    "max_states": 64,
-    "max_full_runs": 8,
+    "max_delta_s": 110,     # 护栏，非工作点
+    "max_delta_v": 110,     # 护栏，非工作点
+    "max_full_runs": 12,
     "min_stable_states": 2,
+    "max_parents": 5,
     "time_budget_ms": 40,
 }
 
 _MODES = {"off", "shadow", "active"}
 
+# 已废弃的配置键：出现时忽略而非报错，避免旧 pipeline 直接 fail closed。
+_OBSOLETE_KEYS = ("max_states",)
 
-class TopologyStates(list):
-    """携带状态空间是否因 max_states 被截断的信息。"""
+# 陪跑档与主档的间距 = 主档增量 × 该比例（下限 2）。这是"邻域"的定义，
+# 是结构参数而非从样本量出的工作点：无论界面怎么变，10% 的扰动都算相邻。
+_NEIGHBOR_RATIO = 0.10
+_NEIGHBOR_MIN_STEP = 2
 
-    def __init__(self, values=(), *, truncated=False, total=0):
-        super().__init__(values)
-        self.truncated = bool(truncated)
-        self.total = int(total)
+# 三个切法的尝试顺序。仅影响预算消耗先后，不影响判定：
+# 位置一致时取增量最小者，位置分散时一律拒绝，与顺序无关。
+DIRECTIONS = ("亮度", "饱和", "双切")
+
+# 主档在 (si, vi) 网格里的落点。同方向的 3 档 vi 相邻(差1)，
+# 不同方向 si 相隔 10 —— 保证 select_stable_winner 的 _adjacent 永不跨方向连通。
+_DIRECTION_SI = {"亮度": 0, "饱和": 10, "双切": 20}
 
 
 def normalize_rescue_config(raw: Any) -> Tuple[Dict[str, Any], Optional[str]]:
@@ -46,33 +59,33 @@ def normalize_rescue_config(raw: Any) -> Tuple[Dict[str, Any], Optional[str]]:
 
     cfg = dict(DEFAULT_RESCUE_CONFIG)
     cfg.update(raw)
+    for key in _OBSOLETE_KEYS:      # 旧 pipeline 残留键：忽略，不因此关闭救援
+        cfg.pop(key, None)
     try:
         cfg["mode"] = str(cfg["mode"]).strip().lower()
         if cfg["mode"] not in _MODES:
             raise ValueError("mode 仅支持 off/shadow/active")
 
-        for key in ("max_delta_s", "max_delta_v", "max_states",
-                    "max_full_runs", "min_stable_states", "time_budget_ms"):
+        for key in ("max_delta_s", "max_delta_v", "max_full_runs",
+                    "min_stable_states", "max_parents", "time_budget_ms"):
             cfg[key] = int(cfg[key])
 
         if cfg["max_delta_s"] <= 0 or cfg["max_delta_v"] <= 0:
             raise ValueError("max_delta_s/v 必须 > 0")
-        if cfg["max_states"] < 2:
-            raise ValueError("max_states 必须 >= 2")
-        if cfg["max_states"] < cfg["min_stable_states"]:
-            raise ValueError("max_states 必须 >= min_stable_states")
         if cfg["max_full_runs"] < cfg["min_stable_states"]:
             raise ValueError("max_full_runs 必须 >= min_stable_states")
         if cfg["min_stable_states"] < 2:
             raise ValueError("min_stable_states 必须 >= 2")
+        if cfg["max_parents"] < 1:
+            raise ValueError("max_parents 必须 >= 1")
         if cfg["time_budget_ms"] <= 0:
             raise ValueError("time_budget_ms 必须 > 0")
         if cfg["max_delta_s"] > 115 or cfg["max_delta_v"] > 135:
             raise ValueError("max_delta_s/v 超过安全上限")
-        if cfg["max_states"] > 256:
-            raise ValueError("max_states 超过安全上限 256")
         if cfg["max_full_runs"] > 32:
             raise ValueError("max_full_runs 超过安全上限 32")
+        if cfg["max_parents"] > 16:
+            raise ValueError("max_parents 超过安全上限 16")
         if cfg["time_budget_ms"] > 2000:
             raise ValueError("time_budget_ms 超过安全上限 2000")
     except (TypeError, ValueError) as exc:
@@ -120,63 +133,142 @@ def mask_digest(mask: np.ndarray) -> str:
     return hashlib.sha1(np.ascontiguousarray(mask).view(np.uint8)).hexdigest()
 
 
-def _events(values: np.ndarray, bases: Iterable[int], maximum: int) -> List[int]:
-    events = {0}
-    if values.size == 0:
-        return [0]
-    for base in bases:
-        margins = values.astype(np.int16) - int(base) + 1
-        for value in np.unique(margins):
-            ivalue = int(value)
-            if 0 < ivalue <= maximum:
-                events.add(ivalue)
-    return sorted(events)
+def otsu_threshold(values: np.ndarray) -> Optional[int]:
+    """大津法：在 0~255 上找使类间方差最大的切点，返回 t（>=t 归为"亮/饱和"的一类）。
+
+    不需要任何预设数值，切点完全由这一堆像素自己的分布决定 —— 这是"泛用"的前提。
+    已知失效条件：两类像素数悬殊会偏向大类；本来单峰时它照样给值。
+    因此切点只是候选，是否采纳由后续完整检测链与跨档复现决定，不在这里下结论。
+    """
+    v = np.asarray(values, dtype=np.int64).ravel()
+    if v.size < 8:
+        return None
+    hist = np.bincount(v, minlength=256).astype(np.float64)
+    total = hist.sum()
+    if total <= 0:
+        return None
+    prob = hist / total
+    idx = np.arange(256, dtype=np.float64)
+    omega = np.cumsum(prob)
+    mu = np.cumsum(prob * idx)
+    mu_total = mu[-1]
+    denom = omega * (1.0 - omega)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        sigma_b = (mu_total * omega - mu) ** 2 / denom
+    sigma_b[~np.isfinite(sigma_b)] = -1.0
+    if float(sigma_b.max()) <= 0.0:
+        return None                      # 完全没有可切之处（常量分布）
+    return int(np.argmax(sigma_b)) + 1
 
 
-def build_topology_states(
-    hsv_np: np.ndarray,
-    eligible_mask: np.ndarray,
-    ranges: Sequence[dict],
-    config: Dict[str, Any],
-) -> List[Dict[str, int]]:
-    """从父 blob 实际 S/V 值生成有界二维拓扑事件状态。"""
-    pixels = hsv_np[eligible_mask]
-    if pixels.size == 0:
-        return []
+def quantile_threshold(values: np.ndarray, q: float) -> Optional[int]:
+    """分位数切点。与 Otsu 相互独立，仅用于交叉验证定点是否可信，不参与判定。"""
+    v = np.asarray(values, dtype=np.int64).ravel()
+    if v.size < 8:
+        return None
+    return int(np.percentile(v, q))
 
-    s_bases, v_bases = [], []
+
+def _channel_base(ranges: Sequence[dict], index: int) -> Optional[int]:
+    """取各红色组在该通道上最松的 lower（收紧以它为基准，保证是严格子集）。"""
+    lows = []
     for item in ranges:
         lower = item.get("lower") or item.get("lower_hsv")
         if isinstance(lower, (list, tuple)) and len(lower) == 3:
-            s_bases.append(int(lower[1]))
-            v_bases.append(int(lower[2]))
-    if not s_bases:
-        return []
+            lows.append(int(lower[index]))
+    return min(lows) if lows else None
 
-    s_events = _events(pixels[:, 1], s_bases, config["max_delta_s"])
-    v_events = _events(pixels[:, 2], v_bases, config["max_delta_v"])
-    max_s = max(1, config["max_delta_s"])
-    max_v = max(1, config["max_delta_v"])
 
-    states = []
-    for si, ds in enumerate(s_events):
-        for vi, dv in enumerate(v_events):
-            if ds == 0 and dv == 0:
-                continue
-            # 先试最小的归一化收紧，再用总增量保证确定性。
-            cost = max(ds / max_s, dv / max_v)
-            states.append({
-                "si": si, "vi": vi, "delta_s": ds, "delta_v": dv,
-                "_cost": cost,
-            })
-    states.sort(key=lambda x: (x["_cost"], x["delta_s"] + x["delta_v"],
-                               x["delta_s"], x["delta_v"]))
-    total = len(states)
-    truncated = total > config["max_states"]
-    states = states[:config["max_states"]]
-    for state in states:
-        state.pop("_cost", None)
-    return TopologyStates(states, truncated=truncated, total=total)
+def channel_cutpoints(parent_pixels: np.ndarray,
+                      ranges: Sequence[dict],
+                      config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """对一个父块算出两个通道的切点与收紧增量，附 Otsu 与分位数的分歧度。
+
+    返回结构直接进回传字段 `救援.切点`，无需二次加工。
+    """
+    px = np.asarray(parent_pixels)
+    if px.ndim != 2 or px.shape[0] < 8 or px.shape[1] < 3:
+        return None
+    s_base = _channel_base(ranges, 1)
+    v_base = _channel_base(ranges, 2)
+    if s_base is None or v_base is None:
+        return None
+
+    out: Dict[str, Any] = {}
+    diverge = []
+    for name, col, base, cap in (("饱和", 1, s_base, config["max_delta_s"]),
+                                 ("亮度", 2, v_base, config["max_delta_v"])):
+        cut = otsu_threshold(px[:, col])
+        qcut = quantile_threshold(px[:, col], 45.0)
+        delta = 0 if cut is None else max(0, min(int(cap), cut - base))
+        out[name] = {"Otsu": cut, "分位": qcut, "基线": base, "增量": delta}
+        if cut is not None and qcut is not None:
+            diverge.append(abs(cut - qcut))
+    out["分歧"] = max(diverge) if diverge else None
+    return out
+
+
+def _neighbor_step(delta: int) -> int:
+    return max(_NEIGHBOR_MIN_STEP, int(round(delta * _NEIGHBOR_RATIO)))
+
+
+def direction_deltas(cutpoints: Dict[str, Any],
+                     direction: str) -> Optional[Tuple[int, int]]:
+    """把切点翻译成某个切法的 (delta_s, delta_v)；无效返回 None。"""
+    ds = int(cutpoints.get("饱和", {}).get("增量") or 0)
+    dv = int(cutpoints.get("亮度", {}).get("增量") or 0)
+    pair = {"亮度": (0, dv), "饱和": (ds, 0), "双切": (ds, dv)}.get(direction)
+    if pair is None or (pair[0] <= 0 and pair[1] <= 0):
+        return None
+    return pair
+
+
+def neighbor_states(direction: str, delta_s: int, delta_v: int,
+                    config: Dict[str, Any]) -> List[Dict[str, int]]:
+    """主档 + 上下两个陪跑档，落在同一 si 上、vi 相邻，供跨档复现判定。
+
+    陪跑档间距按主档增量的比例取，不引入绝对常数；越界或非正的档位自动剔除。
+    """
+    si = _DIRECTION_SI.get(direction, 0)
+    step = _neighbor_step(max(delta_s, delta_v))
+    cap_s, cap_v = config["max_delta_s"], config["max_delta_v"]
+    out = []
+    for vi, mult in ((0, -1), (1, 0), (2, 1)):
+        ns = delta_s + step * mult if delta_s > 0 else 0
+        nv = delta_v + step * mult if delta_v > 0 else 0
+        if (delta_s > 0 and not (0 < ns <= cap_s)) or \
+           (delta_v > 0 and not (0 < nv <= cap_v)):
+            continue
+        if ns <= 0 and nv <= 0:
+            continue
+        out.append({"si": si, "vi": vi, "delta_s": int(ns), "delta_v": int(nv)})
+    return out
+
+
+def sort_parents(parents: Sequence[dict]) -> List[dict]:
+    """按"像不像红点"排先后：短边降序，短边相同按面积降序。零参数，只排序不过滤。
+
+    真红点近似圆/菱形，短边与长边同量级；卡片上的杂红多是细横条或细竖条，短边很小。
+    实测 boss-adb 5 个被拒块中正主排第 1，boss-pc 3 个中正主并列第 1。
+    """
+    def key(p):
+        short = min(int(p.get("w", 0)), int(p.get("h", 0)))
+        return (-short, -int(p.get("area", 0)), int(p.get("label", 0)))
+    return sorted(parents, key=key)
+
+
+def boxes_agree(boxes: Sequence[Sequence[int]], min_iou: float = 0.5,
+                max_center_shift: float = 2.5) -> bool:
+    """多个切法命中的框是否指向同一处。分散即视为方向歧义，一律拒绝。"""
+    if len(boxes) <= 1:
+        return True
+    first = boxes[0]
+    for other in boxes[1:]:
+        if _box_iou(first, other) < min_iou:
+            return False
+        if _center_distance(first, other) > max_center_shift:
+            return False
+    return True
 
 
 def lineage_parent(

--- a/agent/recognition/rdd_hsv_rescue.py
+++ b/agent/recognition/rdd_hsv_rescue.py
@@ -1,0 +1,285 @@
+"""RedDotDetector 严格 HSV 救援的纯算法工具。
+
+本模块不依赖 MaaFramework，也不负责识别副作用。它只处理：
+参数校验、严格 HSV profile、拓扑事件状态、父子 lineage 与跨状态稳定选择。
+运行时和离线回放共用这里，避免出现两套救援算法。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+
+DEFAULT_RESCUE_CONFIG: Dict[str, Any] = {
+    "mode": "off",
+    "max_delta_s": 48,
+    "max_delta_v": 64,
+    "max_states": 64,
+    "max_full_runs": 8,
+    "min_stable_states": 2,
+    "time_budget_ms": 40,
+}
+
+_MODES = {"off", "shadow", "active"}
+
+
+class TopologyStates(list):
+    """携带状态空间是否因 max_states 被截断的信息。"""
+
+    def __init__(self, values=(), *, truncated=False, total=0):
+        super().__init__(values)
+        self.truncated = bool(truncated)
+        self.total = int(total)
+
+
+def normalize_rescue_config(raw: Any) -> Tuple[Dict[str, Any], Optional[str]]:
+    """校验配置。非法配置 fail closed 为 off，并返回原因。"""
+    if raw is None:
+        return dict(DEFAULT_RESCUE_CONFIG), None
+    if not isinstance(raw, dict):
+        cfg = dict(DEFAULT_RESCUE_CONFIG)
+        return cfg, "flt_hsv_rescue 必须是 object"
+
+    cfg = dict(DEFAULT_RESCUE_CONFIG)
+    cfg.update(raw)
+    try:
+        cfg["mode"] = str(cfg["mode"]).strip().lower()
+        if cfg["mode"] not in _MODES:
+            raise ValueError("mode 仅支持 off/shadow/active")
+
+        for key in ("max_delta_s", "max_delta_v", "max_states",
+                    "max_full_runs", "min_stable_states", "time_budget_ms"):
+            cfg[key] = int(cfg[key])
+
+        if cfg["max_delta_s"] <= 0 or cfg["max_delta_v"] <= 0:
+            raise ValueError("max_delta_s/v 必须 > 0")
+        if cfg["max_states"] < 2:
+            raise ValueError("max_states 必须 >= 2")
+        if cfg["max_states"] < cfg["min_stable_states"]:
+            raise ValueError("max_states 必须 >= min_stable_states")
+        if cfg["max_full_runs"] < cfg["min_stable_states"]:
+            raise ValueError("max_full_runs 必须 >= min_stable_states")
+        if cfg["min_stable_states"] < 2:
+            raise ValueError("min_stable_states 必须 >= 2")
+        if cfg["time_budget_ms"] <= 0:
+            raise ValueError("time_budget_ms 必须 > 0")
+        if cfg["max_delta_s"] > 115 or cfg["max_delta_v"] > 135:
+            raise ValueError("max_delta_s/v 超过安全上限")
+        if cfg["max_states"] > 256:
+            raise ValueError("max_states 超过安全上限 256")
+        if cfg["max_full_runs"] > 32:
+            raise ValueError("max_full_runs 超过安全上限 32")
+        if cfg["time_budget_ms"] > 2000:
+            raise ValueError("time_budget_ms 超过安全上限 2000")
+    except (TypeError, ValueError) as exc:
+        disabled = dict(DEFAULT_RESCUE_CONFIG)
+        return disabled, str(exc)
+    return cfg, None
+
+
+def strict_profile(
+    ranges: Sequence[dict], delta_s: int, delta_v: int,
+) -> Optional[List[dict]]:
+    """保持 H/upper 不动，仅同步提高所有组的 S/V lower。"""
+    if delta_s < 0 or delta_v < 0 or (delta_s == 0 and delta_v == 0):
+        return None
+
+    result: List[dict] = []
+    for item in ranges:
+        lower = item.get("lower") or item.get("lower_hsv")
+        upper = item.get("upper") or item.get("upper_hsv")
+        if not isinstance(lower, (list, tuple)) or not isinstance(upper, (list, tuple)):
+            return None
+        if len(lower) != 3 or len(upper) != 3:
+            return None
+        new_lower = [
+            int(lower[0]),
+            min(255, int(lower[1]) + int(delta_s)),
+            min(255, int(lower[2]) + int(delta_v)),
+        ]
+        if any(new_lower[i] > int(upper[i]) for i in range(3)):
+            return None
+        result.append({"lower": new_lower, "upper": [int(v) for v in upper]})
+    return result or None
+
+
+def is_strict_mask(candidate: np.ndarray, baseline: np.ndarray) -> bool:
+    """candidate 必须是 baseline 的真子集。"""
+    if candidate.shape != baseline.shape:
+        return False
+    if np.any(candidate & ~baseline):
+        return False
+    return not np.array_equal(candidate, baseline)
+
+
+def mask_digest(mask: np.ndarray) -> str:
+    return hashlib.sha1(np.ascontiguousarray(mask).view(np.uint8)).hexdigest()
+
+
+def _events(values: np.ndarray, bases: Iterable[int], maximum: int) -> List[int]:
+    events = {0}
+    if values.size == 0:
+        return [0]
+    for base in bases:
+        margins = values.astype(np.int16) - int(base) + 1
+        for value in np.unique(margins):
+            ivalue = int(value)
+            if 0 < ivalue <= maximum:
+                events.add(ivalue)
+    return sorted(events)
+
+
+def build_topology_states(
+    hsv_np: np.ndarray,
+    eligible_mask: np.ndarray,
+    ranges: Sequence[dict],
+    config: Dict[str, Any],
+) -> List[Dict[str, int]]:
+    """从父 blob 实际 S/V 值生成有界二维拓扑事件状态。"""
+    pixels = hsv_np[eligible_mask]
+    if pixels.size == 0:
+        return []
+
+    s_bases, v_bases = [], []
+    for item in ranges:
+        lower = item.get("lower") or item.get("lower_hsv")
+        if isinstance(lower, (list, tuple)) and len(lower) == 3:
+            s_bases.append(int(lower[1]))
+            v_bases.append(int(lower[2]))
+    if not s_bases:
+        return []
+
+    s_events = _events(pixels[:, 1], s_bases, config["max_delta_s"])
+    v_events = _events(pixels[:, 2], v_bases, config["max_delta_v"])
+    max_s = max(1, config["max_delta_s"])
+    max_v = max(1, config["max_delta_v"])
+
+    states = []
+    for si, ds in enumerate(s_events):
+        for vi, dv in enumerate(v_events):
+            if ds == 0 and dv == 0:
+                continue
+            # 先试最小的归一化收紧，再用总增量保证确定性。
+            cost = max(ds / max_s, dv / max_v)
+            states.append({
+                "si": si, "vi": vi, "delta_s": ds, "delta_v": dv,
+                "_cost": cost,
+            })
+    states.sort(key=lambda x: (x["_cost"], x["delta_s"] + x["delta_v"],
+                               x["delta_s"], x["delta_v"]))
+    total = len(states)
+    truncated = total > config["max_states"]
+    states = states[:config["max_states"]]
+    for state in states:
+        state.pop("_cost", None)
+    return TopologyStates(states, truncated=truncated, total=total)
+
+
+def lineage_parent(
+    blob_mask: np.ndarray,
+    baseline_labels: np.ndarray,
+    eligible_parent_ids: Iterable[int],
+) -> Optional[int]:
+    """候选必须完全来自唯一的 eligible baseline 父 blob。"""
+    labels = set(int(v) for v in np.unique(baseline_labels[blob_mask]))
+    labels.discard(0)
+    eligible = set(int(v) for v in eligible_parent_ids)
+    if len(labels) != 1:
+        return None
+    parent = next(iter(labels))
+    return parent if parent in eligible else None
+
+
+def _box_iou(a: Sequence[int], b: Sequence[int]) -> float:
+    ax, ay, aw, ah = [float(v) for v in a]
+    bx, by, bw, bh = [float(v) for v in b]
+    x0, y0 = max(ax, bx), max(ay, by)
+    x1, y1 = min(ax + aw, bx + bw), min(ay + ah, by + bh)
+    inter = max(0.0, x1 - x0) * max(0.0, y1 - y0)
+    union = aw * ah + bw * bh - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _center_distance(a: Sequence[int], b: Sequence[int]) -> float:
+    ax, ay, aw, ah = [float(v) for v in a]
+    bx, by, bw, bh = [float(v) for v in b]
+    return math.hypot((ax + aw / 2) - (bx + bw / 2),
+                      (ay + ah / 2) - (by + bh / 2))
+
+
+def _adjacent(a: dict, b: dict) -> bool:
+    return abs(a["si"] - b["si"]) + abs(a["vi"] - b["vi"]) == 1
+
+
+def select_stable_winner(
+    records: Sequence[dict],
+    min_stable_states: int,
+    min_iou: float = 0.5,
+    max_center_shift: float = 2.5,
+) -> Tuple[Optional[dict], str, List[dict]]:
+    """以相邻拓扑状态组成稳定图；唯一稳定分量才允许 winner。"""
+    if not records:
+        return None, "no_hit", []
+
+    per_state: Dict[Tuple[int, int, int], int] = {}
+    for record in records:
+        key = (int(record["parent_id"]), int(record["state"]["si"]),
+               int(record["state"]["vi"]))
+        per_state[key] = per_state.get(key, 0) + 1
+    if any(count > 1 for count in per_state.values()):
+        return None, "ambiguous_split", []
+
+    graph = [set() for _ in records]
+    for i, left in enumerate(records):
+        for j in range(i + 1, len(records)):
+            right = records[j]
+            if left["parent_id"] != right["parent_id"]:
+                continue
+            if not _adjacent(left["state"], right["state"]):
+                continue
+            if _box_iou(left["box_local"], right["box_local"]) < min_iou:
+                continue
+            if _center_distance(left["box_local"], right["box_local"]) > max_center_shift:
+                continue
+            graph[i].add(j)
+            graph[j].add(i)
+
+    components, seen = [], set()
+    for start in range(len(records)):
+        if start in seen:
+            continue
+        stack, indexes = [start], []
+        seen.add(start)
+        while stack:
+            cur = stack.pop()
+            indexes.append(cur)
+            for nxt in graph[cur]:
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        states = {(records[i]["state"]["si"], records[i]["state"]["vi"]) for i in indexes}
+        if len(states) >= min_stable_states:
+            components.append(indexes)
+
+    support = [{
+        "parent_id": records[idxs[0]]["parent_id"],
+        "states": [records[i]["state"] for i in idxs],
+        "boxes": [list(records[i]["box_local"]) for i in idxs],
+    } for idxs in components]
+
+    if not components:
+        return None, "unstable_hit", support
+    if len(components) != 1:
+        return None, "ambiguous_stable_hits", support
+
+    chosen = min(
+        (records[i] for i in components[0]),
+        key=lambda r: (r["state"]["delta_s"] + r["state"]["delta_v"],
+                       r["state"]["delta_s"], r["state"]["delta_v"],
+                       r.get("scan_index", 0)),
+    )
+    return chosen, "stable_hit", support

--- a/agent/recognition/rdd_sampler.py
+++ b/agent/recognition/rdd_sampler.py
@@ -3,8 +3,13 @@
 # ================================================================
 # 作用：把每次识别(命中/未命中)的小图 + 完整识别信息落成"语料即回归集"：
 #   · 小图：roi_crop / red_mask / inner，唯一命名(时间戳)累积，不覆盖；
-#   · samples.jsonl：一行一事件(时间/节点/roi/box/conf 四项分解/红块几何/生效参数/关联图)。
+#   · samples.jsonl.log：一行一事件(时间/节点/roi/box/conf 四项分解/红块几何/生效参数/关联图)。
 #   事后整个文件夹拿走，即可离线回放：改任何参数先过旧语料，再上真机。
+#
+# 台账为什么叫 .jsonl.log(别改回去)：UI 的"导出日志"按扩展名白名单收集文件，.jsonl
+#   不在名单内会被静默丢掉——2026-07 收到的四个用户回流包共 688 张图全部没有台账，
+#   根因即此(图是 .png 在名单内，台账不在)。没有台账的图对回放器等于零价值：roi /
+#   params / result / box 全在台账里。补一个 .log 后缀即可随包带出，内容仍是 JSONL。
 #
 # 开关(模式)：RDD_SAMPLE 环境变量(off/fail/all) > maa_option.json 的 rdd_sample > 默认 all。
 #   env 穿透运行侧一切配置；fail=只采未命中；off=完全关闭(零开销)。
@@ -30,6 +35,12 @@ import time
 
 import numpy as np
 from PIL import Image
+
+
+# 台账文件名。第一个是现行写入名；其余是历史名，只读端(回放器)须一并识别——
+# 存量语料与用户手上的旧包都还是旧名，改名不能让它们作废。
+MANIFEST_NAME = "samples.jsonl.log"
+MANIFEST_NAMES = (MANIFEST_NAME, "samples.jsonl")
 
 
 class RddSampler:
@@ -87,7 +98,7 @@ class RddSampler:
                     "roi": [int(v) for v in roi]}
             line.update(meta or {})
             line["files"] = files
-            with open(os.path.join(out_dir, "samples.jsonl"), "a", encoding="utf-8") as f:
+            with open(os.path.join(out_dir, MANIFEST_NAME), "a", encoding="utf-8") as f:
                 f.write(json.dumps(line, ensure_ascii=False, default=self._jsonable) + "\n")
 
             self._last_ts[key] = now

--- a/agent/recognition/replay_rdd_samples.py
+++ b/agent/recognition/replay_rdd_samples.py
@@ -33,6 +33,11 @@ def _load_crop(path):
     return np.array(Image.fromarray(bgr[..., ::-1]).convert("HSV"))
 
 
+def _recorded_rescue(entry):
+    """兼容两代键名：`救援`(现行，与 detail 金字塔同为中文键)与 `rescue`(2026-07 的 3 条旧记录)。"""
+    return entry.get("救援") or entry.get("rescue") or {}
+
+
 def _expected_local(entry):
     box = entry.get("box")
     if not box:
@@ -113,8 +118,7 @@ def replay(sample_dir, rescue=False, expected_rescue_nodes=()):
                 gap_ratio=gap_ratio, min_conf=min_conf, rx=0, ry=0,
                 config=rescue_cfg,
             )
-            stable = (rescue_result.get("decision") == "stable_hit"
-                      and rescue_result.get("search_complete"))
+            stable = rescue_result.get("_decision") == "stable_hit"
             if stable:
                 rescue_stable += 1
 
@@ -122,12 +126,16 @@ def replay(sample_dir, rescue=False, expected_rescue_nodes=()):
         if (expected_rescue is None and entry.get("node") in expected_rescue_nodes
                 and not outcome["hit"] and stage == "aspect"):
             expected_rescue = True
-        recorded_rescue = entry.get("rescue") or {}
-        recorded_active = (recorded_rescue.get("mode") == "active"
+        recorded_rescue = _recorded_rescue(entry)
+        recorded_mode = recorded_rescue.get("模式") or recorded_rescue.get("mode")
+        recorded_active = (recorded_mode == "active"
                            and expected_hit and not outcome["hit"])
-        if (expected_rescue is None and recorded_rescue.get("mode") == "active"
-                and not outcome["hit"]):
-            expected_rescue = expected_hit
+        # 只在"旧版 active 曾经救回过"时才要求新版也救回。反向不成立：
+        # 旧算法救不出，不等于新算法不该救出 —— 那正是迭代要改进的部分。
+        # （2026-07-11 的 2 条 active 记录即属此类：旧网格爬失败，新直方图定点成功。）
+        if (expected_rescue is None and recorded_mode == "active"
+                and not outcome["hit"] and expected_hit):
+            expected_rescue = True
         if expected_rescue is not None:
             rescue_checks += 1
             checked_rescue_nodes.add(entry.get("node"))
@@ -138,8 +146,8 @@ def replay(sample_dir, rescue=False, expected_rescue_nodes=()):
                     "line": index, "node": entry.get("node"),
                     "expected_rescue": bool(expected_rescue),
                     "actual_rescue": stable,
-                    "decision": (rescue_result or {}).get("decision"),
-                    "stop_reason": (rescue_result or {}).get("stop_reason"),
+                    "decision": (rescue_result or {}).get("_decision"),
+                    "stop_reason": (rescue_result or {}).get("停因"),
                 })
             if recorded_active and stable:
                 winner = rescue_result.get("_winner")

--- a/agent/recognition/replay_rdd_samples.py
+++ b/agent/recognition/replay_rdd_samples.py
@@ -1,4 +1,4 @@
-"""只读回放 RedDotDetector_samples/samples.jsonl。
+"""只读回放 RedDotDetector_samples 的台账(samples.jsonl.log，兼容旧名 samples.jsonl)。
 
 运行示例（从仓库根目录）：
     python agent/recognition/replay_rdd_samples.py assets/debug/RedDotDetector_samples
@@ -25,6 +25,25 @@ from recognition.binarymatch import (  # noqa: E402
     _FLT_ASPECT_DEFAULT,
 )
 from recognition.rdd_hsv_rescue import normalize_rescue_config  # noqa: E402
+from recognition.rdd_sampler import MANIFEST_NAMES  # noqa: E402
+
+
+def _load_entries(sample_dir):
+    """读齐目录内所有台账。旧名在前(产生更早)，同目录两名并存时合并而非二选一。"""
+    entries, used = [], []
+    for name in reversed(MANIFEST_NAMES):
+        path = os.path.join(sample_dir, name)
+        if not os.path.isfile(path):
+            continue
+        with open(path, "r", encoding="utf-8") as stream:
+            rows = [json.loads(line) for line in stream if line.strip()]
+        entries.extend(rows)
+        used.append(f"{name}({len(rows)})")
+    if not used:
+        raise SystemExit(
+            f"{sample_dir} 下没有台账，找过：{'、'.join(MANIFEST_NAMES)}")
+    print(f"台账：{'、'.join(used)}", file=sys.stderr)
+    return entries
 
 
 def _load_crop(path):
@@ -49,15 +68,13 @@ def _expected_local(entry):
 
 
 def replay(sample_dir, rescue=False, expected_rescue_nodes=()):
-    manifest = os.path.join(sample_dir, "samples.jsonl")
     detector = RedDotDetector()
     total = parity = box_parity = rescue_stable = rescue_trigger = 0
     rescue_checks = rescue_pass = skipped_no_crop = 0
     checked_rescue_nodes = set()
     mismatches = []
 
-    with open(manifest, "r", encoding="utf-8") as stream:
-        entries = [json.loads(line) for line in stream if line.strip()]
+    entries = _load_entries(sample_dir)
 
     fallback_rescue = {
         "mode": "shadow",

--- a/agent/recognition/replay_rdd_samples.py
+++ b/agent/recognition/replay_rdd_samples.py
@@ -1,0 +1,216 @@
+"""只读回放 RedDotDetector_samples/samples.jsonl。
+
+运行示例（从仓库根目录）：
+    python agent/recognition/replay_rdd_samples.py assets/debug/RedDotDetector_samples
+    python agent/recognition/replay_rdd_samples.py assets/debug/RedDotDetector_samples \
+        --rescue --expect-rescue-node Pass_SelectPass
+"""
+
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+from PIL import Image
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT_ROOT = os.path.dirname(HERE)
+if AGENT_ROOT not in sys.path:
+    sys.path.insert(0, AGENT_ROOT)
+
+from recognition.binarymatch import (  # noqa: E402
+    RedDotDetector,
+    _FLT_ASPECT_DEFAULT,
+)
+from recognition.rdd_hsv_rescue import normalize_rescue_config  # noqa: E402
+
+
+def _load_crop(path):
+    rgb = np.array(Image.open(path).convert("RGB"))
+    bgr = rgb[..., ::-1]
+    return np.array(Image.fromarray(bgr[..., ::-1]).convert("HSV"))
+
+
+def _expected_local(entry):
+    box = entry.get("box")
+    if not box:
+        return None
+    if entry.get("mode") == "standalone":
+        roi = entry.get("roi") or [0, 0, 0, 0]
+        return [box[0] - roi[0], box[1] - roi[1], box[2], box[3]]
+    return list(box)
+
+
+def replay(sample_dir, rescue=False, expected_rescue_nodes=()):
+    manifest = os.path.join(sample_dir, "samples.jsonl")
+    detector = RedDotDetector()
+    total = parity = box_parity = rescue_stable = rescue_trigger = 0
+    rescue_checks = rescue_pass = skipped_no_crop = 0
+    checked_rescue_nodes = set()
+    mismatches = []
+
+    with open(manifest, "r", encoding="utf-8") as stream:
+        entries = [json.loads(line) for line in stream if line.strip()]
+
+    fallback_rescue = {
+        "mode": "shadow",
+        "max_delta_s": 48,
+        "max_delta_v": 64,
+        "max_states": 128,
+        "max_full_runs": 24,
+        "min_stable_states": 2,
+        "time_budget_ms": 1000,
+    }
+    expected_rescue_nodes = set(expected_rescue_nodes or [])
+
+    for index, entry in enumerate(entries, 1):
+        crop_name = next(
+            (name for name in entry.get("files", []) if name.endswith("_roi_crop.png")),
+            None,
+        )
+        if not crop_name:
+            skipped_no_crop += 1
+            mismatches.append({
+                "line": index, "node": entry.get("node"),
+                "error": "missing roi_crop",
+            })
+            continue
+        hsv_np = _load_crop(os.path.join(sample_dir, crop_name))
+        params = entry.get("params") or {}
+        hsv_ranges = (params.get("configured_hsv_ranges")
+                      or params["hsv_ranges"])
+        area_min, area_max = params.get("red_area", [30, 1200])
+        asp_lo, asp_hi = params.get("flt_aspect", _FLT_ASPECT_DEFAULT)
+        min_conf = params.get("min_conf", 0.55)
+        gap_ratio = params.get("gap_ratio", 0.35)
+        outcome = detector._detect_once(
+            hsv_np, hsv_ranges, area_min, area_max, asp_lo, asp_hi,
+            gap_ratio, min_conf, 0, 0,
+        )
+        stage, _ = detector._diagnose(outcome["stat"], area_min, area_max, min_conf)
+        expected_hit = entry.get("result") == "hit"
+        total += 1
+
+        rescue_result = None
+        stable = False
+        if rescue and not outcome["hit"] and stage == "aspect":
+            rescue_trigger += 1
+            raw_rescue = dict(params.get("flt_hsv_rescue") or fallback_rescue)
+            raw_rescue["mode"] = "shadow"
+            rescue_cfg, rescue_error = normalize_rescue_config(raw_rescue)
+            if rescue_error:
+                mismatches.append({
+                    "line": index, "node": entry.get("node"),
+                    "rescue_config_error": rescue_error,
+                })
+                continue
+            rescue_result = detector._run_hsv_rescue(
+                hsv_np=hsv_np, baseline=outcome, hsv_ranges=hsv_ranges,
+                area_range=(area_min, area_max),
+                aspect_range=(asp_lo, asp_hi),
+                gap_ratio=gap_ratio, min_conf=min_conf, rx=0, ry=0,
+                config=rescue_cfg,
+            )
+            stable = (rescue_result.get("decision") == "stable_hit"
+                      and rescue_result.get("search_complete"))
+            if stable:
+                rescue_stable += 1
+
+        expected_rescue = entry.get("expected_rescue")
+        if (expected_rescue is None and entry.get("node") in expected_rescue_nodes
+                and not outcome["hit"] and stage == "aspect"):
+            expected_rescue = True
+        recorded_rescue = entry.get("rescue") or {}
+        recorded_active = (recorded_rescue.get("mode") == "active"
+                           and expected_hit and not outcome["hit"])
+        if (expected_rescue is None and recorded_rescue.get("mode") == "active"
+                and not outcome["hit"]):
+            expected_rescue = expected_hit
+        if expected_rescue is not None:
+            rescue_checks += 1
+            checked_rescue_nodes.add(entry.get("node"))
+            if stable == bool(expected_rescue):
+                rescue_pass += 1
+            else:
+                mismatches.append({
+                    "line": index, "node": entry.get("node"),
+                    "expected_rescue": bool(expected_rescue),
+                    "actual_rescue": stable,
+                    "decision": (rescue_result or {}).get("decision"),
+                    "stop_reason": (rescue_result or {}).get("stop_reason"),
+                })
+            if recorded_active and stable:
+                winner = rescue_result.get("_winner")
+                actual_box = (list(winner["candidate"]["box_local"])
+                              if winner is not None else None)
+                expected_box = _expected_local(entry)
+                if actual_box != expected_box:
+                    mismatches.append({
+                        "line": index, "node": entry.get("node"),
+                        "expected_active_box": expected_box,
+                        "actual_active_box": actual_box,
+                    })
+                actual_profile = (winner.get("profile")
+                                  if winner is not None else None)
+                expected_profile = params.get("effective_hsv_ranges")
+                if expected_profile is not None and actual_profile != expected_profile:
+                    mismatches.append({
+                        "line": index, "node": entry.get("node"),
+                        "expected_active_profile": expected_profile,
+                        "actual_active_profile": actual_profile,
+                    })
+
+        expected_baseline_hit = False if recorded_active else expected_hit
+        if outcome["hit"] == expected_baseline_hit:
+            parity += 1
+        else:
+            mismatches.append({
+                "line": index, "node": entry.get("node"),
+                "expected_baseline": "hit" if expected_baseline_hit else "miss",
+                "actual": "hit" if outcome["hit"] else stage,
+            })
+            continue
+
+        if expected_hit and not recorded_active:
+            actual_box = list(outcome["candidates"][0]["box_local"])
+            expected_box = _expected_local(entry)
+            if actual_box == expected_box:
+                box_parity += 1
+            else:
+                mismatches.append({
+                    "line": index, "node": entry.get("node"),
+                    "expected_box": expected_box, "actual_box": actual_box,
+                })
+
+    if total == 0:
+        mismatches.append({"error": "no replayable samples"})
+    for node in expected_rescue_nodes - checked_rescue_nodes:
+        mismatches.append({
+            "node": node,
+            "error": "no aspect-stage rescue sample was checked",
+        })
+
+    print(json.dumps({
+        "total": total,
+        "result_parity": parity,
+        "hit_box_parity": box_parity,
+        "skipped_no_crop": skipped_no_crop,
+        "rescue_trigger": rescue_trigger,
+        "rescue_stable": rescue_stable,
+        "rescue_checks": rescue_checks,
+        "rescue_pass": rescue_pass,
+        "mismatches": mismatches,
+    }, ensure_ascii=False, indent=2))
+    return 0 if not mismatches else 1
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sample_dir")
+    parser.add_argument("--rescue", action="store_true")
+    parser.add_argument("--expect-rescue-node", action="append", default=[])
+    args = parser.parse_args()
+    raise SystemExit(replay(
+        os.path.abspath(args.sample_dir), args.rescue, args.expect_rescue_node))

--- a/agent/recognition/test_rdd_hsv_rescue.py
+++ b/agent/recognition/test_rdd_hsv_rescue.py
@@ -4,20 +4,30 @@ import numpy as np
 
 try:
     from .rdd_hsv_rescue import (
-        build_topology_states,
+        boxes_agree,
+        channel_cutpoints,
+        direction_deltas,
         is_strict_mask,
         lineage_parent,
+        neighbor_states,
         normalize_rescue_config,
+        otsu_threshold,
         select_stable_winner,
+        sort_parents,
         strict_profile,
     )
 except ImportError:
     from rdd_hsv_rescue import (
-        build_topology_states,
+        boxes_agree,
+        channel_cutpoints,
+        direction_deltas,
         is_strict_mask,
         lineage_parent,
+        neighbor_states,
         normalize_rescue_config,
+        otsu_threshold,
         select_stable_winner,
+        sort_parents,
         strict_profile,
     )
 
@@ -41,9 +51,17 @@ class RescueConfigTest(unittest.TestCase):
         self.assertEqual(config["mode"], "off")
 
         config, error = normalize_rescue_config(
-            {"mode": "active", "max_states": 10000})
+            {"mode": "active", "max_parents": 100})
         self.assertIsNotNone(error)
         self.assertEqual(config["mode"], "off")
+
+    def test_obsolete_key_is_ignored_not_fatal(self):
+        """旧 pipeline 残留的 max_states 不应把救援直接关掉。"""
+        config, error = normalize_rescue_config(
+            {"mode": "shadow", "max_states": 64})
+        self.assertIsNone(error)
+        self.assertEqual(config["mode"], "shadow")
+        self.assertNotIn("max_states", config)
 
     def test_strict_profile_only_raises_sv_lower(self):
         profile = strict_profile(RANGES, 12, 18)
@@ -52,7 +70,7 @@ class RescueConfigTest(unittest.TestCase):
         self.assertEqual(profile[0]["upper"], RANGES[0]["upper"])
 
 
-class TopologyStateTest(unittest.TestCase):
+class CutpointAndCandidateTest(unittest.TestCase):
     def test_candidate_mask_must_be_true_subset(self):
         baseline = np.array([[1, 1], [0, 1]], dtype=bool)
         same = baseline.copy()
@@ -62,34 +80,79 @@ class TopologyStateTest(unittest.TestCase):
         self.assertTrue(is_strict_mask(strict, baseline))
         self.assertFalse(is_strict_mask(wider, baseline))
 
-    def test_states_come_from_observed_sv_events(self):
-        hsv = np.zeros((2, 2, 3), dtype=np.uint8)
-        hsv[..., 1] = [[140, 149], [160, 180]]
-        hsv[..., 2] = [[120, 129], [150, 180]]
-        eligible = np.ones((2, 2), dtype=bool)
-        config, _ = normalize_rescue_config({
-            "mode": "shadow", "max_delta_s": 30, "max_delta_v": 40,
-            "max_states": 32,
-        })
-        states = build_topology_states(hsv, eligible, RANGES, config)
-        deltas = {(s["delta_s"], s["delta_v"]) for s in states}
-        self.assertIn((1, 0), deltas)
-        self.assertIn((0, 1), deltas)
-        self.assertNotIn((0, 0), deltas)
+    def test_otsu_splits_two_peaks_and_refuses_degenerate(self):
+        two_peaks = np.array([150] * 40 + [220] * 40, dtype=np.uint8)
+        cut = otsu_threshold(two_peaks)
+        self.assertIsNotNone(cut)
+        self.assertTrue(150 < cut <= 220, cut)
+        self.assertIsNone(otsu_threshold(np.full(40, 180, dtype=np.uint8)))
+        self.assertIsNone(otsu_threshold(np.array([1, 2, 3], dtype=np.uint8)))
 
-    def test_state_budget_reports_truncation(self):
-        hsv = np.zeros((3, 3, 3), dtype=np.uint8)
-        hsv[..., 1] = np.arange(140, 149).reshape(3, 3)
-        hsv[..., 2] = np.arange(120, 129).reshape(3, 3)
-        config, error = normalize_rescue_config({
-            "mode": "shadow", "max_delta_s": 20, "max_delta_v": 20,
-            "max_states": 2, "min_stable_states": 2,
-        })
-        self.assertIsNone(error)
-        states = build_topology_states(
-            hsv, np.ones((3, 3), dtype=bool), RANGES, config)
-        self.assertTrue(states.truncated)
-        self.assertGreater(states.total, len(states))
+    def test_cutpoints_come_from_parent_pixels_and_respect_cap(self):
+        """切点由父块自身分布算出；护栏只封顶，不充当工作点。"""
+        pixels = np.zeros((80, 3), dtype=np.uint8)
+        pixels[:, 1] = [160] * 40 + [230] * 40     # 饱和度双峰
+        pixels[:, 2] = [130] * 40 + [210] * 40     # 亮度双峰
+        config, _ = normalize_rescue_config({"mode": "shadow"})
+        cuts = channel_cutpoints(pixels, RANGES, config)
+        self.assertGreater(cuts["亮度"]["增量"], 0)
+        self.assertGreater(cuts["饱和"]["增量"], 0)
+        self.assertEqual(cuts["亮度"]["基线"], 120)
+        self.assertEqual(cuts["饱和"]["基线"], 140)
+
+        tight, _ = normalize_rescue_config(
+            {"mode": "shadow", "max_delta_v": 5, "max_delta_s": 5})
+        capped = channel_cutpoints(pixels, RANGES, tight)
+        self.assertEqual(capped["亮度"]["增量"], 5)
+        self.assertEqual(capped["饱和"]["增量"], 5)
+
+    def test_direction_deltas_cover_three_cuts(self):
+        cuts = {"饱和": {"增量": 40}, "亮度": {"增量": 50}}
+        self.assertEqual(direction_deltas(cuts, "亮度"), (0, 50))
+        self.assertEqual(direction_deltas(cuts, "饱和"), (40, 0))
+        self.assertEqual(direction_deltas(cuts, "双切"), (40, 50))
+        # 某通道无增量时，该方向不成立（避免生成 (0,0) 的空收紧）
+        flat = {"饱和": {"增量": 0}, "亮度": {"增量": 0}}
+        self.assertIsNone(direction_deltas(flat, "双切"))
+
+    def test_neighbor_states_are_adjacent_and_bounded(self):
+        config, _ = normalize_rescue_config({"mode": "shadow"})
+        states = neighbor_states("亮度", 0, 50, config)
+        self.assertEqual(len(states), 3)
+        self.assertEqual({s["si"] for s in states}, {0})
+        self.assertEqual([s["vi"] for s in states], [0, 1, 2])
+        self.assertEqual([s["delta_v"] for s in states], [45, 50, 55])
+        self.assertTrue(all(s["delta_s"] == 0 for s in states))
+
+        # 越过护栏的档位被剔除，不会溢出上限
+        tight, _ = normalize_rescue_config(
+            {"mode": "shadow", "max_delta_v": 52})
+        bounded = neighbor_states("亮度", 0, 50, tight)
+        self.assertTrue(all(s["delta_v"] <= 52 for s in bounded))
+        self.assertLess(len(bounded), 3)
+
+        # 不同切法落在互不相邻的 si 上，避免跨方向连通成同一分量
+        self.assertNotEqual(neighbor_states("亮度", 0, 50, config)[0]["si"],
+                            neighbor_states("双切", 40, 50, config)[0]["si"])
+
+    def test_sort_parents_puts_thick_blocks_first(self):
+        """短边越大越像红点；实测 boss-adb 的正主(53x16)应排第一。"""
+        parents = [
+            {"label": 1, "w": 34, "h": 5, "area": 103},
+            {"label": 2, "w": 53, "h": 16, "area": 239},
+            {"label": 3, "w": 6, "h": 15, "area": 52},
+            {"label": 4, "w": 50, "h": 15, "area": 258},
+        ]
+        order = [p["label"] for p in sort_parents(parents)]
+        self.assertEqual(order[0], 2)
+        self.assertEqual(order[-1], 1)
+
+    def test_boxes_agree_rejects_scattered_hits(self):
+        same = [(10, 10, 12, 12), (10, 11, 12, 12)]
+        apart = [(10, 10, 12, 12), (60, 60, 12, 12)]
+        self.assertTrue(boxes_agree(same))
+        self.assertFalse(boxes_agree(apart))
+        self.assertTrue(boxes_agree([(0, 0, 5, 5)]))
 
 
 class LineageAndStabilityTest(unittest.TestCase):

--- a/agent/recognition/test_rdd_hsv_rescue.py
+++ b/agent/recognition/test_rdd_hsv_rescue.py
@@ -1,0 +1,152 @@
+import unittest
+
+import numpy as np
+
+try:
+    from .rdd_hsv_rescue import (
+        build_topology_states,
+        is_strict_mask,
+        lineage_parent,
+        normalize_rescue_config,
+        select_stable_winner,
+        strict_profile,
+    )
+except ImportError:
+    from rdd_hsv_rescue import (
+        build_topology_states,
+        is_strict_mask,
+        lineage_parent,
+        normalize_rescue_config,
+        select_stable_winner,
+        strict_profile,
+    )
+
+
+RANGES = [
+    {"lower": [0, 140, 120], "upper": [12, 255, 255]},
+    {"lower": [165, 140, 120], "upper": [180, 255, 255]},
+]
+
+
+class RescueConfigTest(unittest.TestCase):
+    def test_default_is_off(self):
+        config, error = normalize_rescue_config(None)
+        self.assertIsNone(error)
+        self.assertEqual(config["mode"], "off")
+
+    def test_invalid_config_fails_closed(self):
+        config, error = normalize_rescue_config(
+            {"mode": "active", "min_stable_states": 3, "max_full_runs": 2})
+        self.assertIsNotNone(error)
+        self.assertEqual(config["mode"], "off")
+
+        config, error = normalize_rescue_config(
+            {"mode": "active", "max_states": 10000})
+        self.assertIsNotNone(error)
+        self.assertEqual(config["mode"], "off")
+
+    def test_strict_profile_only_raises_sv_lower(self):
+        profile = strict_profile(RANGES, 12, 18)
+        self.assertEqual(profile[0]["lower"], [0, 152, 138])
+        self.assertEqual(profile[1]["lower"], [165, 152, 138])
+        self.assertEqual(profile[0]["upper"], RANGES[0]["upper"])
+
+
+class TopologyStateTest(unittest.TestCase):
+    def test_candidate_mask_must_be_true_subset(self):
+        baseline = np.array([[1, 1], [0, 1]], dtype=bool)
+        same = baseline.copy()
+        strict = np.array([[1, 0], [0, 1]], dtype=bool)
+        wider = np.array([[1, 1], [1, 1]], dtype=bool)
+        self.assertFalse(is_strict_mask(same, baseline))
+        self.assertTrue(is_strict_mask(strict, baseline))
+        self.assertFalse(is_strict_mask(wider, baseline))
+
+    def test_states_come_from_observed_sv_events(self):
+        hsv = np.zeros((2, 2, 3), dtype=np.uint8)
+        hsv[..., 1] = [[140, 149], [160, 180]]
+        hsv[..., 2] = [[120, 129], [150, 180]]
+        eligible = np.ones((2, 2), dtype=bool)
+        config, _ = normalize_rescue_config({
+            "mode": "shadow", "max_delta_s": 30, "max_delta_v": 40,
+            "max_states": 32,
+        })
+        states = build_topology_states(hsv, eligible, RANGES, config)
+        deltas = {(s["delta_s"], s["delta_v"]) for s in states}
+        self.assertIn((1, 0), deltas)
+        self.assertIn((0, 1), deltas)
+        self.assertNotIn((0, 0), deltas)
+
+    def test_state_budget_reports_truncation(self):
+        hsv = np.zeros((3, 3, 3), dtype=np.uint8)
+        hsv[..., 1] = np.arange(140, 149).reshape(3, 3)
+        hsv[..., 2] = np.arange(120, 129).reshape(3, 3)
+        config, error = normalize_rescue_config({
+            "mode": "shadow", "max_delta_s": 20, "max_delta_v": 20,
+            "max_states": 2, "min_stable_states": 2,
+        })
+        self.assertIsNone(error)
+        states = build_topology_states(
+            hsv, np.ones((3, 3), dtype=bool), RANGES, config)
+        self.assertTrue(states.truncated)
+        self.assertGreater(states.total, len(states))
+
+
+class LineageAndStabilityTest(unittest.TestCase):
+    def test_lineage_requires_one_eligible_parent(self):
+        labels = np.array([[1, 1, 0], [0, 2, 2]], dtype=np.int32)
+        child = np.array([[1, 0, 0], [0, 0, 0]], dtype=bool)
+        mixed = np.array([[1, 0, 0], [0, 1, 0]], dtype=bool)
+        self.assertEqual(lineage_parent(child, labels, [1]), 1)
+        self.assertIsNone(lineage_parent(child, labels, [2]))
+        self.assertIsNone(lineage_parent(mixed, labels, [1, 2]))
+
+    def test_two_adjacent_states_form_unique_stable_winner(self):
+        records = [
+            {"parent_id": 1, "box_local": (10, 10, 12, 12),
+             "state": {"si": 1, "vi": 0, "delta_s": 5, "delta_v": 0},
+             "scan_index": 1},
+            {"parent_id": 1, "box_local": (10, 10, 11, 12),
+             "state": {"si": 2, "vi": 0, "delta_s": 8, "delta_v": 0},
+             "scan_index": 1},
+        ]
+        winner, reason, support = select_stable_winner(records, 2)
+        self.assertEqual(reason, "stable_hit")
+        self.assertIs(winner, records[0])
+        self.assertEqual(len(support), 1)
+
+    def test_single_state_and_multiple_tracks_fail_closed(self):
+        one = [{"parent_id": 1, "box_local": (0, 0, 10, 10),
+                "state": {"si": 1, "vi": 0, "delta_s": 1, "delta_v": 0}}]
+        winner, reason, _ = select_stable_winner(one, 2)
+        self.assertIsNone(winner)
+        self.assertEqual(reason, "unstable_hit")
+
+        ambiguous = [
+            {"parent_id": 1, "box_local": (0, 0, 10, 10),
+             "state": {"si": 1, "vi": 0, "delta_s": 1, "delta_v": 0}},
+            {"parent_id": 1, "box_local": (0, 0, 10, 10),
+             "state": {"si": 2, "vi": 0, "delta_s": 2, "delta_v": 0}},
+            {"parent_id": 2, "box_local": (20, 20, 10, 10),
+             "state": {"si": 1, "vi": 0, "delta_s": 1, "delta_v": 0}},
+            {"parent_id": 2, "box_local": (20, 20, 10, 10),
+             "state": {"si": 2, "vi": 0, "delta_s": 2, "delta_v": 0}},
+        ]
+        winner, reason, _ = select_stable_winner(ambiguous, 2)
+        self.assertIsNone(winner)
+        self.assertEqual(reason, "ambiguous_stable_hits")
+
+    def test_split_in_same_parent_state_is_ambiguous(self):
+        records = [
+            {"parent_id": 1, "box_local": (0, 0, 10, 10),
+             "state": {"si": 1, "vi": 0, "delta_s": 1, "delta_v": 0}},
+            {"parent_id": 1, "box_local": (20, 0, 10, 10),
+             "state": {"si": 1, "vi": 0, "delta_s": 1, "delta_v": 0}},
+        ]
+        winner, reason, _ = select_stable_winner(records, 2)
+        self.assertIsNone(winner)
+        self.assertEqual(reason, "ambiguous_split")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/assets/resource/base/pipeline/Dummy.json
+++ b/assets/resource/base/pipeline/Dummy.json
@@ -123,11 +123,11 @@
             "sc_gap_ratio": 0.35,
             "flt_hsv_rescue": {
                 "mode": "shadow",
-                "max_delta_s": 48,
-                "max_delta_v": 64,
-                "max_states": 64,
-                "max_full_runs": 8,
+                "max_delta_s": 110,
+                "max_delta_v": 110,
+                "max_full_runs": 12,
                 "min_stable_states": 2,
+                "max_parents": 5,
                 "time_budget_ms": 40
             }
         }
@@ -168,11 +168,11 @@
             "sc_gap_ratio": 0.35,
             "flt_hsv_rescue": {
                 "mode": "shadow",
-                "max_delta_s": 48,
-                "max_delta_v": 64,
-                "max_states": 64,
-                "max_full_runs": 8,
+                "max_delta_s": 110,
+                "max_delta_v": 110,
+                "max_full_runs": 12,
                 "min_stable_states": 2,
+                "max_parents": 5,
                 "time_budget_ms": 40
             }
         }

--- a/assets/resource/base/pipeline/Dummy.json
+++ b/assets/resource/base/pipeline/Dummy.json
@@ -120,7 +120,16 @@
                 1200
             ],
             "sc_min_conf": 0.55,
-            "sc_gap_ratio": 0.35
+            "sc_gap_ratio": 0.35,
+            "flt_hsv_rescue": {
+                "mode": "shadow",
+                "max_delta_s": 48,
+                "max_delta_v": 64,
+                "max_states": 64,
+                "max_full_runs": 8,
+                "min_stable_states": 2,
+                "time_budget_ms": 40
+            }
         }
     },
     "Agt_RedDot_Preset_Panoram": {
@@ -156,7 +165,16 @@
                 450
             ],
             "sc_min_conf": 0.58,
-            "sc_gap_ratio": 0.35
+            "sc_gap_ratio": 0.35,
+            "flt_hsv_rescue": {
+                "mode": "shadow",
+                "max_delta_s": 48,
+                "max_delta_v": 64,
+                "max_states": 64,
+                "max_full_runs": 8,
+                "min_stable_states": 2,
+                "time_budget_ms": 40
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

引入严格的基于 HSV 的补救（rescue）流水线，用于处理 RedDotDetector 的纵横比（aspect）失败场景，并改进诊断、日志记录和回放工具。

New Features:
- 添加严格的 HSV 补救算法，通过拓扑、谱系（lineage）以及跨波段稳定性检查，恢复因纵横比过滤而被拒绝的真实红点。
- 支持在预设模式下向调用方传递有效 HSV 范围以及嵌套的 raw_detail，包括补救元数据。
- 提供 RedDotDetector 样本的离线回放工具，用于在录制数据上验证基线和补救行为。

Enhancements:
- 将 RedDotDetector 核心检测重构为可复用、无副作用的 `_detect_once` 流水线，以支持补救和回放。
- 扩展遗漏和调试报告，加入本地化阶段总结、纵横比拒绝统计以及结构化失败转储元数据。
- 改进 native vision echo，使其使用实际结果框和有效 HSV 范围，避免在大 ROI 中出现覆盖不匹配的问题。

Tests:
- 新增 `rdd_hsv_rescue` 的单元测试套件，覆盖配置校验、切分点（cutpoint）计算、父节点排序、谱系（lineage）以及稳定优胜者选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce strict HSV-based rescue pipeline for RedDotDetector aspect failures and improve diagnostics, logging, and replay tooling.

New Features:
- Add strict HSV rescue algorithm to recover true red dots rejected by aspect ratio filtering using topology, lineage, and cross-band stability checks.
- Support preset mode propagation of effective HSV ranges and nested raw_detail, including rescue metadata, to callers.
- Provide an offline replay tool for RedDotDetector samples to validate baseline and rescue behavior over recorded data.

Enhancements:
- Refactor RedDotDetector core detection into a reusable, side-effect-free _detect_once pipeline to support rescue and replay.
- Extend miss and debug reporting with localized stage summaries, aspect rejection statistics, and structured failure dump metadata.
- Improve native vision echo to use actual result boxes and effective HSV ranges, avoiding mismatched overlays in large ROIs.

Tests:
- Add unit test suite for rdd_hsv_rescue covering config validation, cutpoint computation, parent sorting, lineage, and stable winner selection.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入严格的基于 HSV 的补救（rescue）流水线，用于处理 RedDotDetector 的纵横比（aspect）失败场景，并改进诊断、日志记录和回放工具。

New Features:
- 添加严格的 HSV 补救算法，通过拓扑、谱系（lineage）以及跨波段稳定性检查，恢复因纵横比过滤而被拒绝的真实红点。
- 支持在预设模式下向调用方传递有效 HSV 范围以及嵌套的 raw_detail，包括补救元数据。
- 提供 RedDotDetector 样本的离线回放工具，用于在录制数据上验证基线和补救行为。

Enhancements:
- 将 RedDotDetector 核心检测重构为可复用、无副作用的 `_detect_once` 流水线，以支持补救和回放。
- 扩展遗漏和调试报告，加入本地化阶段总结、纵横比拒绝统计以及结构化失败转储元数据。
- 改进 native vision echo，使其使用实际结果框和有效 HSV 范围，避免在大 ROI 中出现覆盖不匹配的问题。

Tests:
- 新增 `rdd_hsv_rescue` 的单元测试套件，覆盖配置校验、切分点（cutpoint）计算、父节点排序、谱系（lineage）以及稳定优胜者选择。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce strict HSV-based rescue pipeline for RedDotDetector aspect failures and improve diagnostics, logging, and replay tooling.

New Features:
- Add strict HSV rescue algorithm to recover true red dots rejected by aspect ratio filtering using topology, lineage, and cross-band stability checks.
- Support preset mode propagation of effective HSV ranges and nested raw_detail, including rescue metadata, to callers.
- Provide an offline replay tool for RedDotDetector samples to validate baseline and rescue behavior over recorded data.

Enhancements:
- Refactor RedDotDetector core detection into a reusable, side-effect-free _detect_once pipeline to support rescue and replay.
- Extend miss and debug reporting with localized stage summaries, aspect rejection statistics, and structured failure dump metadata.
- Improve native vision echo to use actual result boxes and effective HSV ranges, avoiding mismatched overlays in large ROIs.

Tests:
- Add unit test suite for rdd_hsv_rescue covering config validation, cutpoint computation, parent sorting, lineage, and stable winner selection.

</details>

</details>