### PR TITLE
Merge:'feat/qsmloc'| Qmsg改为自建

### DIFF
--- a/.github/workflows/NotePush_Iss&Pr_Scheduled.yml
+++ b/.github/workflows/NotePush_Iss&Pr_Scheduled.yml
@@ -328,19 +328,32 @@ jobs:
           MSG: ${{ steps.generate_message.outputs.message }}
         run: |
           # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          # 本 step 跑在 bash -e 下，裸命令返回非零会立刻掐断脚本，
+          # 故 curl / jq 一律显式接管退出码，保证失败时诊断信息能打出来
+          if [ -z "$NOTIFY_URL" ] || [ -z "$QMSG_GROUPS" ]; then
+            echo "::error::NOTIFY_URL 或 QMSG_GROUPS 未配置"
+            exit 1
+          fi
           FAIL=0
-          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
-          for GID in "${GROUPS[@]}"; do
-            GID="$(echo "$GID" | xargs)"
-            [ -z "$GID" ] && continue
-            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+          # 不加引号的命令替换借词分割顺带剥掉群号两侧空白；群号为纯数字，无 glob 风险
+          for GID in $(echo "$QMSG_GROUPS" | tr ',' ' '); do
+            BODY=$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}') || {
+              echo "::error::群号非法: $GID"
+              FAIL=1
+              continue
+            }
+            RC=0
+            RESP=$(curl -sS --max-time 60 -w '\n%{http_code}' -X POST "${NOTIFY_URL}/send_group_msg" \
               -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
-            echo "NapCat 响应($GID): $RESP"
-            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              -d "$BODY") || RC=$?
+            CODE=$(printf '%s' "$RESP" | tail -n1)
+            JSON=$(printf '%s' "$RESP" | sed '$d')
+            echo "群 $GID → curl_rc=$RC http=$CODE 响应: $JSON"
+            if [ "$RC" -ne 0 ] || [ "$CODE" != "200" ] \
+               || ! printf '%s' "$JSON" | jq -e '.status == "ok" and .retcode == 0' >/dev/null 2>&1; then
               echo "::error::推送到群 $GID 失败"
               FAIL=1
-            }
+            fi
           done
-          [ "$FAIL" -eq 0 ] || exit 1
+          if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/.github/workflows/NotePush_Iss&Pr_Scheduled.yml
+++ b/.github/workflows/NotePush_Iss&Pr_Scheduled.yml
@@ -321,17 +321,26 @@ jobs:
         if: steps.fetch_activities.outputs.total_count != '0'
         env:
           # 经 env 注入，避免用户可控的消息内容直接拼进命令行
-          QMSG_KEY: ${{ secrets.QMSG_KEY }}
+          # 自建中继（NapCat OneBot HTTP，经 Cloudflare Tunnel 暴露），已不再依赖 qmsg.zendee.cn
+          NOTIFY_URL: ${{ secrets.NOTIFY_URL }}
+          NOTIFY_TOKEN: ${{ secrets.NOTIFY_TOKEN }}
           QMSG_GROUPS: ${{ secrets.QMSG_GROUPS_PUB }}
           MSG: ${{ steps.generate_message.outputs.message }}
         run: |
-          # 直发 Qmsg 群消息：POST /group/<KEY>，--data-urlencode 自动处理换行与特殊字符
-          RESP=$(curl -sS --max-time 60 -X POST "https://qmsg.zendee.cn/group/${QMSG_KEY}" \
-            --data-urlencode "msg=${MSG}" \
-            --data-urlencode "qq=${QMSG_GROUPS}")
-          echo "Qmsg 响应: $RESP"
-          # 校验服务端 success 字段，失败则让步骤失败（与原 action 行为一致）
-          echo "$RESP" | jq -e '.success == true' >/dev/null || {
-            echo "::error::Qmsg 推送失败"
-            exit 1
-          }
+          # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          FAIL=0
+          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
+          for GID in "${GROUPS[@]}"; do
+            GID="$(echo "$GID" | xargs)"
+            [ -z "$GID" ] && continue
+            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+              -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
+            echo "NapCat 响应($GID): $RESP"
+            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              echo "::error::推送到群 $GID 失败"
+              FAIL=1
+            }
+          done
+          [ "$FAIL" -eq 0 ] || exit 1

--- a/.github/workflows/NotePush_Issues_Real-time.yml
+++ b/.github/workflows/NotePush_Issues_Real-time.yml
@@ -172,22 +172,35 @@ jobs:
         run: |
           MSG="$TITLE"$'\n'"$CONTENT"
           # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          # 本 step 跑在 bash -e 下，裸命令返回非零会立刻掐断脚本，
+          # 故 curl / jq 一律显式接管退出码，保证失败时诊断信息能打出来
+          if [ -z "$NOTIFY_URL" ] || [ -z "$QMSG_GROUPS" ]; then
+            echo "::error::NOTIFY_URL 或 QMSG_GROUPS 未配置"
+            exit 1
+          fi
           FAIL=0
-          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
-          for GID in "${GROUPS[@]}"; do
-            GID="$(echo "$GID" | xargs)"
-            [ -z "$GID" ] && continue
-            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+          # 不加引号的命令替换借词分割顺带剥掉群号两侧空白；群号为纯数字，无 glob 风险
+          for GID in $(echo "$QMSG_GROUPS" | tr ',' ' '); do
+            BODY=$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}') || {
+              echo "::error::群号非法: $GID"
+              FAIL=1
+              continue
+            }
+            RC=0
+            RESP=$(curl -sS --max-time 60 -w '\n%{http_code}' -X POST "${NOTIFY_URL}/send_group_msg" \
               -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
-            echo "NapCat 响应($GID): $RESP"
-            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              -d "$BODY") || RC=$?
+            CODE=$(printf '%s' "$RESP" | tail -n1)
+            JSON=$(printf '%s' "$RESP" | sed '$d')
+            echo "群 $GID → curl_rc=$RC http=$CODE 响应: $JSON"
+            if [ "$RC" -ne 0 ] || [ "$CODE" != "200" ] \
+               || ! printf '%s' "$JSON" | jq -e '.status == "ok" and .retcode == 0' >/dev/null 2>&1; then
               echo "::error::推送到群 $GID 失败"
               FAIL=1
-            }
+            fi
           done
-          [ "$FAIL" -eq 0 ] || exit 1
+          if [ "$FAIL" -ne 0 ]; then exit 1; fi
       
       - name: Skip Notification Log
         if: steps.prepare_message.outputs.skip_notification == 'true'

--- a/.github/workflows/NotePush_Issues_Real-time.yml
+++ b/.github/workflows/NotePush_Issues_Real-time.yml
@@ -163,20 +163,31 @@ jobs:
         if: steps.prepare_message.outputs.skip_notification != 'true'
         env:
           # 经 env 注入，避免用户可控内容（Issue 标题等）直接拼进命令行
-          QMSG_KEY: ${{ secrets.QMSG_KEY }}
+          # 自建中继（NapCat OneBot HTTP，经 Cloudflare Tunnel 暴露），已不再依赖 qmsg.zendee.cn
+          NOTIFY_URL: ${{ secrets.NOTIFY_URL }}
+          NOTIFY_TOKEN: ${{ secrets.NOTIFY_TOKEN }}
           QMSG_GROUPS: ${{ secrets.QMSG_GROUPS_DEV }}
           TITLE: ${{ steps.prepare_message.outputs.title }}
           CONTENT: ${{ steps.prepare_message.outputs.content }}
         run: |
           MSG="$TITLE"$'\n'"$CONTENT"
-          RESP=$(curl -sS --max-time 60 -X POST "https://qmsg.zendee.cn/group/${QMSG_KEY}" \
-            --data-urlencode "msg=${MSG}" \
-            --data-urlencode "qq=${QMSG_GROUPS}")
-          echo "Qmsg 响应: $RESP"
-          echo "$RESP" | jq -e '.success == true' >/dev/null || {
-            echo "::error::Qmsg 推送失败"
-            exit 1
-          }
+          # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          FAIL=0
+          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
+          for GID in "${GROUPS[@]}"; do
+            GID="$(echo "$GID" | xargs)"
+            [ -z "$GID" ] && continue
+            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+              -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
+            echo "NapCat 响应($GID): $RESP"
+            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              echo "::error::推送到群 $GID 失败"
+              FAIL=1
+            }
+          done
+          [ "$FAIL" -eq 0 ] || exit 1
       
       - name: Skip Notification Log
         if: steps.prepare_message.outputs.skip_notification == 'true'

--- a/.github/workflows/NotePush_PullRequest_Real-time.yml
+++ b/.github/workflows/NotePush_PullRequest_Real-time.yml
@@ -83,17 +83,28 @@ jobs:
       - name: Send QQ Notification
         env:
           # 经 env 注入，避免用户可控内容（PR 标题等）直接拼进命令行
-          QMSG_KEY: ${{ secrets.QMSG_KEY }}
+          # 自建中继（NapCat OneBot HTTP，经 Cloudflare Tunnel 暴露），已不再依赖 qmsg.zendee.cn
+          NOTIFY_URL: ${{ secrets.NOTIFY_URL }}
+          NOTIFY_TOKEN: ${{ secrets.NOTIFY_TOKEN }}
           QMSG_GROUPS: ${{ secrets.QMSG_GROUPS_DEV }}
           TITLE: ${{ steps.prepare_msg.outputs.title }}
           CONTENT: ${{ steps.prepare_msg.outputs.content }}
         run: |
           MSG="$TITLE"$'\n'"$CONTENT"
-          RESP=$(curl -sS --max-time 60 -X POST "https://qmsg.zendee.cn/group/${QMSG_KEY}" \
-            --data-urlencode "msg=${MSG}" \
-            --data-urlencode "qq=${QMSG_GROUPS}")
-          echo "Qmsg 响应: $RESP"
-          echo "$RESP" | jq -e '.success == true' >/dev/null || {
-            echo "::error::Qmsg 推送失败"
-            exit 1
-          }
+          # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          FAIL=0
+          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
+          for GID in "${GROUPS[@]}"; do
+            GID="$(echo "$GID" | xargs)"
+            [ -z "$GID" ] && continue
+            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+              -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
+            echo "NapCat 响应($GID): $RESP"
+            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              echo "::error::推送到群 $GID 失败"
+              FAIL=1
+            }
+          done
+          [ "$FAIL" -eq 0 ] || exit 1

--- a/.github/workflows/NotePush_PullRequest_Real-time.yml
+++ b/.github/workflows/NotePush_PullRequest_Real-time.yml
@@ -92,19 +92,32 @@ jobs:
         run: |
           MSG="$TITLE"$'\n'"$CONTENT"
           # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          # 本 step 跑在 bash -e 下，裸命令返回非零会立刻掐断脚本，
+          # 故 curl / jq 一律显式接管退出码，保证失败时诊断信息能打出来
+          if [ -z "$NOTIFY_URL" ] || [ -z "$QMSG_GROUPS" ]; then
+            echo "::error::NOTIFY_URL 或 QMSG_GROUPS 未配置"
+            exit 1
+          fi
           FAIL=0
-          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
-          for GID in "${GROUPS[@]}"; do
-            GID="$(echo "$GID" | xargs)"
-            [ -z "$GID" ] && continue
-            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+          # 不加引号的命令替换借词分割顺带剥掉群号两侧空白；群号为纯数字，无 glob 风险
+          for GID in $(echo "$QMSG_GROUPS" | tr ',' ' '); do
+            BODY=$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}') || {
+              echo "::error::群号非法: $GID"
+              FAIL=1
+              continue
+            }
+            RC=0
+            RESP=$(curl -sS --max-time 60 -w '\n%{http_code}' -X POST "${NOTIFY_URL}/send_group_msg" \
               -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
-            echo "NapCat 响应($GID): $RESP"
-            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              -d "$BODY") || RC=$?
+            CODE=$(printf '%s' "$RESP" | tail -n1)
+            JSON=$(printf '%s' "$RESP" | sed '$d')
+            echo "群 $GID → curl_rc=$RC http=$CODE 响应: $JSON"
+            if [ "$RC" -ne 0 ] || [ "$CODE" != "200" ] \
+               || ! printf '%s' "$JSON" | jq -e '.status == "ok" and .retcode == 0' >/dev/null 2>&1; then
               echo "::error::推送到群 $GID 失败"
               FAIL=1
-            }
+            fi
           done
-          [ "$FAIL" -eq 0 ] || exit 1
+          if [ "$FAIL" -ne 0 ]; then exit 1; fi

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -964,7 +964,9 @@ jobs:
       - name: Send Notification
         env:
           # 经 env 注入，避免用户可控内容直接拼进命令行
-          QMSG_KEY: ${{ secrets.QMSG_KEY }}
+          # 自建中继（NapCat OneBot HTTP，经 Cloudflare Tunnel 暴露），已不再依赖 qmsg.zendee.cn
+          NOTIFY_URL: ${{ secrets.NOTIFY_URL }}
+          NOTIFY_TOKEN: ${{ secrets.NOTIFY_TOKEN }}
           QMSG_GROUPS: ${{ needs.meta.outputs.version_type == 'ci' && secrets.QMSG_GROUPS_DEV || needs.meta.outputs.version_type != 'ci' && secrets.QMSG_GROUPS_PUB || '' }}
           MSG: |
             🏗️ [${{ github.repository }}] 构建完成
@@ -979,12 +981,20 @@ jobs:
             🔗 查看提交: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
             🔨 构建下载: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          # 直发 Qmsg 群消息：POST /group/<KEY>
-          RESP=$(curl -sS --max-time 60 -X POST "https://qmsg.zendee.cn/group/${QMSG_KEY}" \
-            --data-urlencode "msg=${MSG}" \
-            --data-urlencode "qq=${QMSG_GROUPS}")
-          echo "Qmsg 响应: $RESP"
-          echo "$RESP" | jq -e '.success == true' >/dev/null || {
-            echo "::error::Qmsg 推送失败"
-            exit 1
-          }
+          # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          FAIL=0
+          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
+          for GID in "${GROUPS[@]}"; do
+            GID="$(echo "$GID" | xargs)"
+            [ -z "$GID" ] && continue
+            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+              -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
+              -H "Content-Type: application/json" \
+              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
+            echo "NapCat 响应($GID): $RESP"
+            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              echo "::error::推送到群 $GID 失败"
+              FAIL=1
+            }
+          done
+          [ "$FAIL" -eq 0 ] || exit 1

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -982,19 +982,32 @@ jobs:
             🔨 构建下载: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           # 直发 NapCat OneBot 群消息：POST /send_group_msg，QMSG_GROUPS 可为逗号分隔的多个群号
+          # 本 step 跑在 bash -e 下，裸命令返回非零会立刻掐断脚本，
+          # 故 curl / jq 一律显式接管退出码，保证失败时诊断信息能打出来
+          if [ -z "$NOTIFY_URL" ] || [ -z "$QMSG_GROUPS" ]; then
+            echo "::error::NOTIFY_URL 或 QMSG_GROUPS 未配置"
+            exit 1
+          fi
           FAIL=0
-          IFS=',' read -ra GROUPS <<< "$QMSG_GROUPS"
-          for GID in "${GROUPS[@]}"; do
-            GID="$(echo "$GID" | xargs)"
-            [ -z "$GID" ] && continue
-            RESP=$(curl -sS --max-time 60 -X POST "${NOTIFY_URL}/send_group_msg" \
+          # 不加引号的命令替换借词分割顺带剥掉群号两侧空白；群号为纯数字，无 glob 风险
+          for GID in $(echo "$QMSG_GROUPS" | tr ',' ' '); do
+            BODY=$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}') || {
+              echo "::error::群号非法: $GID"
+              FAIL=1
+              continue
+            }
+            RC=0
+            RESP=$(curl -sS --max-time 60 -w '\n%{http_code}' -X POST "${NOTIFY_URL}/send_group_msg" \
               -H "Authorization: Bearer ${NOTIFY_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "$(jq -n --arg gid "$GID" --arg msg "$MSG" '{group_id: ($gid | tonumber), message: $msg}')")
-            echo "NapCat 响应($GID): $RESP"
-            echo "$RESP" | jq -e '.status == "ok" and .retcode == 0' >/dev/null || {
+              -d "$BODY") || RC=$?
+            CODE=$(printf '%s' "$RESP" | tail -n1)
+            JSON=$(printf '%s' "$RESP" | sed '$d')
+            echo "群 $GID → curl_rc=$RC http=$CODE 响应: $JSON"
+            if [ "$RC" -ne 0 ] || [ "$CODE" != "200" ] \
+               || ! printf '%s' "$JSON" | jq -e '.status == "ok" and .retcode == 0' >/dev/null 2>&1; then
               echo "::error::推送到群 $GID 失败"
               FAIL=1
-            }
+            fi
           done
-          [ "$FAIL" -eq 0 ] || exit 1
+          if [ "$FAIL" -ne 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 将所有工作流通知步骤更新为通过可配置的 NOTIFY_URL/NOTIFY_TOKEN OneBot 端点发送群消息，支持多个目标群组，并提供更健壮的错误报告和失败处理机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update all workflow notification steps to send group messages via a configurable NOTIFY_URL/NOTIFY_TOKEN OneBot endpoint, with support for multiple target groups and more robust error reporting and failure handling.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - QQ 群通知改用自建 NapCat OneBot HTTP 中继发送。
  - 支持通过配置指定通知地址、令牌及多个群号，并按群逐一推送。
- **错误修复**
  - 增加配置、群号、网络请求、HTTP 状态及接口响应校验。
  - 推送失败时提供失败汇总，并确保相关流程正确标记为失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->