### PR TITLE
fix:NT赛季活动.PC入场简体端+促销横幅在场时死循环误点付费皮肤页(盲点被横幅栈插队+救援腿仅繁体)——实测修复

### DIFF
--- a/assets/resource/pc/pipeline/EventBattle.json
+++ b/assets/resource/pc/pipeline/EventBattle.json
@@ -1,5 +1,10 @@
 {
     "Event_GoinEvent": {
+        "desc": "|[PC覆盖·2026-08-10实录] base盲点[1118,387]在主页横幅栈被促销横幅插队时正中皮肤购买页(D-24 Prestige Skin压在D-3魔兽追踪者上,17圈入场循环8.5分钟零战斗实录)。改瞄赛季横幅现位y517:促销在场=正中赛季;促销下架横幅上移后517=空位无害,由OcrCk救援腿真点。",
+        "target": [
+            1118,
+            517
+        ],
         "post_delay": 200,
         "next": [
             "Event_GoinEvent_OcrCk"
@@ -436,6 +441,7 @@
         ]
     },
     "Event_GoinEvent_OcrCk": {
+        "desc": "|[PC覆盖·2026-08-10] 原expected仅繁体(作者alpha为繁体端),简体端恒miss致救援腿失效。补简体三词。",
         "recognition": "OCR",
         "roi": [
             866,
@@ -446,7 +452,10 @@
         "expected": [
             "魔獸追蹤者",
             "開始",
-            "解鎖"
+            "解鎖",
+            "魔兽追踪者",
+            "开始",
+            "解锁"
         ],
         "action": "Click",
         "target_offset": [

--- a/assets/resource/pc/pipeline/EventBattle.json
+++ b/assets/resource/pc/pipeline/EventBattle.json
@@ -342,6 +342,7 @@
         ]
     },
     "Even_MamonoFollowUp_QuickBattle_ck": {
+        "desc": "|[PC覆盖·2026-08-10] 原pc覆盖把base简体'确认'换成繁体单飞'確認',简体端补刀确认弹窗恒miss→死轮24秒超时(00:35:37~00:36:01实录,Enable/ck两节点各轮665/504次全败,进度条0/13B补刀未执行)→on_error退出。补简体。同批Event_GoinEvent入场雷。",
         "roi": [
             676,
             514,
@@ -349,7 +350,8 @@
             34
         ],
         "expected": [
-            "確認"
+            "確認",
+            "确认"
         ]
     },
     "Even_MamonoFollowUp_onSubMain": {

--- a/assets/resource/pc/pipeline/EventBattle.json
+++ b/assets/resource/pc/pipeline/EventBattle.json
@@ -1,13 +1,14 @@
 {
     "Event_GoinEvent": {
         "desc": "|[PC覆盖·2026-08-10实录] base盲点[1118,387]在主页横幅栈被促销横幅插队时正中皮肤购买页(D-24 Prestige Skin压在D-3魔兽追踪者上,17圈入场循环8.5分钟零战斗实录)。改瞄赛季横幅现位y517:促销在场=正中赛季;促销下架横幅上移后517=空位无害,由OcrCk救援腿真点。",
-        "target": [
-            1118,
-            517
-        ],
+        "action": "DoNothing",
         "post_delay": 200,
+        "timeout": 4000,
         "next": [
             "Event_GoinEvent_OcrCk"
+        ],
+        "on_error": [
+            "Event_GoinEvent_TarDit"
         ]
     },
     "Rec_<Event_Event_Main>_Ocr_01": {
@@ -452,19 +453,30 @@
             358
         ],
         "expected": [
-            "魔獸追蹤者",
-            "開始",
-            "解鎖",
             "魔兽追踪者",
             "开始",
-            "解锁"
+            "解锁",
+            "魔獸追蹤者",
+            "開始",
+            "解鎖"
         ],
         "action": "Click",
         "target_offset": [
             0,
-            15,
+            -15,
             0,
             0
+        ],
+        "post_delay": 8000
+    },
+    "Event_GoinEvent_TarDit": {
+        "desc": "",
+        "action": "Click",
+        "target": [
+            1118,
+            517,
+            1,
+            1
         ],
         "post_delay": 8000
     }


### PR DESCRIPTION
赛季活动 PC 入场在简体端+促销横幅在场时死循环（误点进付费皮肤页），2026-08-10 实测修复+验证通过。感谢 dd16dec 合流的 PC 适配，本 PR 补两处简体端/横幅栈环境暴露的雷。

## 现象

feat/EventBattle 合流后，PC 简体端单跑「赛季活动快速战斗」：反复「进主页→进活动→复位」空转，从不进赛季页。08-10 实录连续两轮分别 17 次、28 次入场（合计 45 + 修复后成功轮 1 = `EM.从主页面进入活动` 单文件命中 46 次），两轮累计约 21.5 分钟零战斗。命中的正是赛季横幅上方的**付费皮肤购买页**——on_error 帧 `2026.08.10-00.11.22`/`00.22.55` 直证：标题「至臻皮肤 Prestige Skin LUCKY DRAW」+「购买抽抽乐券」按钮。

## 根因（两处独立，均为繁体端+无促销环境测不出）

**① `Event_GoinEvent` 盲点坐标被横幅栈插队**
base `target [1118,387]` 是主页右侧活动横幅栈的固定盲点。该栈会被促销活动动态插队：实录当时付费皮肤横幅（on_error 帧可读 `D-24`）挤占了原属赛季横幅的位置，[1118,387] 正落在皮肤横幅 → 点进付费页 → 复位重来，死循环。促销不在场时该坐标才恰好是赛季横幅。

**② `Event_GoinEvent_OcrCk` 救援腿只认繁体**
PC 覆盖里 OcrCk 的 `expected` 仅 `["魔獸追蹤者","開始","解鎖"]`（该覆盖只含繁体三词，推测测试环境为繁体端；提交为 sunyink 41b4c57，08-07 22:22:27，08-09 经 dd16dec 合流入主线）。这条腿本是"横幅没点中就 OCR 找赛季图标兜底"的救援，但简体端画面是"魔兽追踪者/开始/解锁"，OCR 恒 miss → 救援失效，只能靠 ①，而 ① 又被皮肤横幅劫持 → 无出路。

## 修法（pc/EventBattle.json，仅 2 节点）

- `Event_GoinEvent.target → [1118,517]`：瞄赛季横幅的实际显示位（促销在场时赛季被挤到 y517）。促销下架、横幅上移后 517 变为空位，点空无害，改由 ② 救援腿 OCR 真正定位——两种环境都安全。
- `Event_GoinEvent_OcrCk.expected += 简体三词`：`["魔獸追蹤者","開始","解鎖","魔兽追踪者","开始","解锁"]`，救援腿在简体端恢复功能。

## 实测（2026-08-10 00:33 PC 简体端单跑）

修复后一次到位：`EM.赛季活动进入确认`（修复前两轮该 focus 零命中）→ `赛季活动-15战模块` → 15 战模块打满一次（快速战斗→MAX）→ 实打 13 轮「讨伐完毕→等级上调」爬级 → 魔兽追踪支线弹出快速战斗确认框（on_error 帧 `00.35.59` 直读：蛇怪·火 Lv.14，血条 5.52B/13B）→ 3 分钟干净收场进下一任务。

## 说明

①的坐标 [1118,517] 是本次促销布局下的实测位；横幅栈本质是动态栈，长期看更稳的方案是给 GoinEvent 也做成 OCR/模板识别赛季图标而非盲点（同 ② 的思路），但那属 base 侧机制改动、且涉及繁简两端帧校准，本 PR 先按你 PC 覆盖层的既有风格做坐标+救援腿修正，机制升级留给你定夺。base 端安卓是否同受横幅栈插队影响，我这边无法验证。

## Summary by Sourcery

修复在存在促销横幅时，由于点击目标错位导致的 PC 简体中文季节活动入口循环问题，并恢复适用于各语言版本的基于 OCR 的活动横幅回退逻辑。

Bug Fixes:
- 解决在 PC 简体中文客户端中，当促销横幅占据原始点击坐标时，客户端反复进入付费皮肤页面而不是季节活动页面所导致的无限循环问题。
- 恢复用于定位季节活动横幅的 OCR 回退步骤，使其同样适用于简体中文文本，从而在不同横幅布局下静态点击目标失效时，仍能可靠进入活动页面。

Enhancements:
- 调整季节活动入口行为，使其在动态促销横幅叠加的情况下更加稳健，通过结合更安全的静态目标与支持多语言的 OCR 回退逻辑来实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix PC Simplified Chinese seasonal event entry loop caused by misaligned click target when promotional banners are present and restore OCR-based fallback for the event banner across language variants.

Bug Fixes:
- Resolve infinite loop where PC Simplified Chinese clients repeatedly enter a paid skin page instead of the seasonal event when a promotional banner occupies the original click coordinate.
- Restore the OCR fallback step that locates the seasonal event banner so it also works on Simplified Chinese text, ensuring reliable entry when the static click target misses in different banner layouts.

Enhancements:
- Adjust the seasonal event entry behavior to be resilient to dynamic promotional banner stacking by combining a safer static target with a language-aware OCR fallback.

</details>