### PR TITLE
feat(ci): 发布时附带资源专用包, 让 GitHub 免费通道也能做资源热更

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1008,6 +1008,36 @@ jobs:
             (cd "$dir" && zip -r "../release_assets/$zip_name" .)
           done
 
+      - name: Package resource-only pack
+        env:
+          TAG: ${{ needs.meta.outputs.tag }}
+        run: |
+          # 资源专用包：只含 resource/ 与 interface.json。
+          #
+          # 为什么要它：适配改动几乎都落在 pipeline JSON 上，而全量包 200MB+。
+          # 让用户为几行 JSON 的适配重下 200MB 是纯浪费，也是发版当天被催更的来源之一。
+          # 资源热更这件事 mirrorchyan_release.yml 的 mirrorchyan_res 已经在做
+          # （pick_files 就是同一份清单），只是仅挂在 MirrorChyan 上、需要付费 CDK。
+          # 这里把同样的东西也放进 GitHub 免费通道，CI 成本是多打一个几 MB 的 zip。
+          #
+          # 排除 model/：OCR 模型是构建时从 MFABD2-Assets 注入的，与游戏版本无关，
+          # 却占资源目录的绝大部分（实测 82.5MB / 86.1MB）。装机的全量包里已经有了，
+          # 热更没有理由反复搬运。实测排除后 3.6MB，约为全量包的 1/58。
+          #
+          # 注意：MFAAvalonia 自带的更新器有已知 bug（见 mirrorchyan_release.yml 里的
+          # 注释：会误做全量更新并删掉 ocr），所以走 MFAA 更新器的用户仍应使用
+          # MirrorChyan 通道那个含 ocr 的包；本资源包面向自己管理更新的用户与脚本。
+          cd artifacts
+          win_dir=$(ls -d MFABD2-*-win-x86_64 2>/dev/null | head -1)
+          if [ -z "$win_dir" ] || [ ! -d "$win_dir/resource" ]; then
+            echo "::warning::找不到 win-x86_64 产物或其 resource 目录，跳过资源包"
+            exit 0
+          fi
+          (cd "$win_dir" && zip -r "../release_assets/MFABD2-RES-${TAG}.zip" \
+              resource interface.json -x 'resource/*/model/*' 'resource/model/*')
+          size=$(du -h "release_assets/MFABD2-RES-${TAG}.zip" | cut -f1)
+          echo "✅ 资源包 MFABD2-RES-${TAG}.zip ($size)，来源 $win_dir"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:


### PR DESCRIPTION
## 问题

适配改动几乎都落在 pipeline JSON 上，而全量包 200MB+。让用户为几行 JSON 的适配重下 200MB 是纯浪费，也是发版当天被催更的来源之一。

实测我这台机器上的部署实例：

| | 体积 |
|---|---|
| 全量包（v4.3.18-alpha 的 win-x86_64.zip） | 208.2 MB |
| 其中 `resource/` | 86.1 MB |
| 其中 `resource/*/model/`（OCR 模型） | 82.5 MB |
| **`resource/` 去掉 model + interface.json** | **3.6 MB** |

也就是说，真正随游戏版本腐烂的那部分只有 **3.6MB，约为全量包的 1/58**。

## 方案

资源热更这件事仓库里其实**已经在做**——`mirrorchyan_release.yml` 的 `mirrorchyan_res` job 用 `pick_files` 抽的就是同一份清单（`resource` + `interface.json`）。只是它仅挂在 MirrorChyan 上、需要付费 CDK，而且要手动 dispatch。

本 PR 把同样的东西也放进 GitHub Releases，让免费通道的用户也能只下几 MB。CI 成本是多打一个 zip。

改动只新增一个 step，不触碰现有的打包与发布逻辑；找不到 win 产物时打 warning 后跳过，不会让发布失败。

### 关于排除 `model/`

OCR 模型是构建时从 `MFABD2-Assets` 注入的，与游戏版本无关（年频腐烂），却占资源目录的绝大部分。装机的全量包里已经有了，热更没有理由反复搬运它。

**MFAAvalonia 更新器的那个已知 bug 不受影响**：你在 `mirrorchyan_release.yml:66` 的注释里写过「MFAA 有时对热更新错误地进行全量更新操作，删除 ocr 并从热更包寻找替代」，所以那边的包才被迫含 ocr。这个 PR 不动那条通道——走 MFAA 更新器的用户仍然使用 MirrorChyan 那个含 ocr 的包；本资源包面向自己管理更新的用户与脚本（这类用户会自己保留原有的 model 目录）。

如果你觉得为了省心还是该把 ocr 一起打进去，把 `-x` 那两行去掉即可，包会变成 86MB，仍比全量包小一半以上。

## 顺带一提

我在本地写了个配套的资源更新脚本（下载 → 只解出 resource + interface.json → 落地前用 `check_resource.py` 试加载 → 任务名 diff 防止搅乱用户队列 → 快照 → 原子替换 → 可一键回滚），目前是 PowerShell 的，只对 Windows 用户有用，所以没放进这个 PR。如果你觉得这类脚本值得进仓库（或者更适合做成跨平台的 Python 版），我可以另开一个 PR。

## Summary by Sourcery

在完整版本发布的同时发布一个轻量级的仅资源包，使用户可以在无需下载完整发行版的情况下更新游戏资源。

新功能：
- 在 GitHub Releases 中添加一个小型的仅资源 ZIP 包，用于轻量级资源更新。

增强改进：
- 将 OCR 模型文件排除在仅资源包之外，以避免重新分发与版本无关的资源。
- 当 Windows 构建产物或资源目录不可用时，跳过资源包的创建并给出警告，但不使发布流程失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Publish a lightweight resource-only package alongside full releases so users can update game resources without downloading the complete distribution.

New Features:
- Add a small resource-only ZIP package to GitHub Releases for lightweight resource updates.

Enhancements:
- Exclude OCR model files from the resource-only package to avoid redistributing version-independent assets.
- Skip resource-package creation with a warning when the Windows artifact or resource directory is unavailable, without failing releases.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 发布流程新增资源专用压缩包。
  * 压缩包包含资源文件和接口配置，并排除资源模型目录。
  * 文件名带有版本标签，便于识别和下载对应版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->