### PR TITLE
fix:NT吸取.快速卡带四类页签选中判据阈值PC化(count 500在PC结构性不可达致无界自环)

### DIFF
--- a/assets/resource/pc/pipeline/Collect_Launcher.json
+++ b/assets/resource/pc/pipeline/Collect_Launcher.json
@@ -43,6 +43,10 @@
             "活動遊戲卡"
         ]
     },
+    "Collect_QuickCart_EventPack_OcrCheck": {
+        "desc": "PC:选中态页签文字框仅65x12=780px,base的count 500需64%覆盖率,PC字形上限约48%(实测373/374)恒判负->SelectType自环无界;下调至300(与CharacterPack同lower同值,PC实测406通过),未选中态实测0,分离度充足",
+        "count": 300
+    },
     "Collect_QuickCart_SelectType_ManagerPack": {
         "roi": [
             15,
@@ -54,6 +58,10 @@
             "店长游戏卡",
             "店長遊戲卡"
         ]
+    },
+    "Collect_QuickCart_ManagerPack_OcrCheck": {
+        "desc": "PC:同EventPack,base count 500在PC不可达,预防性下调300",
+        "count": 300
     },
     "Collect_QuickCart_SelectType_BattleplayPack": {
         "roi": [
@@ -67,6 +75,10 @@
             "戰鬥遊戲卡"
         ]
     },
+    "Collect_QuickCart_BattleplayPack_OcrCheck": {
+        "desc": "PC:同EventPack,base count 500在PC不可达,预防性下调300",
+        "count": 300
+    },
     "Collect_QuickCart_SelectType_LifeplayPack": {
         "roi": [
             15,
@@ -78,6 +90,10 @@
             "生活玩法游戏卡",
             "生活遊戲卡"
         ]
+    },
+    "Collect_QuickCart_LifeplayPack_OcrCheck": {
+        "desc": "PC:同EventPack,base count 500在PC不可达,预防性下调300",
+        "count": 300
     },
     "Collect_FirstBootPack_To1": {
         "target": [


### PR DESCRIPTION
建议标签：PC端

## 现象

PC 端「地图采集[完整]」跑完角色包、切到**活动游戏卡**页签后陷入 **1.1 秒/圈的无界自环**（08-24 04:22 实录 105+ 圈，人工中止）。全程每节点 `success: true`，Exception 零触发，**Panic 不接管**——属 #445 假成功死锁谱系。

环体：
```
Collect_QuickCart_SelectType_EventPack (OCR 命中「活动游戏卡」→ Click)
  next = [Collect_QuickCart_EventPack_OcrCheck, 自身]   ← 无 max_hit
Collect_QuickCart_EventPack_OcrCheck (ColorMatch) 恒判负 → 回落自点
```

## 根因（已用 maafw 自报数据坐实，非推测）

**页签点击本身是有效的**——实机帧证活动页签已选中、下排卡带已换成活动卡带。死的只有校验腿：

| 节点 | base 阈值 | PC 实测 count | 结果 |
| --- | --- | --- | --- |
| `Collect_QuickCart_CharacterPack_OcrCheck` | 300 | **406** | ✅ 每日实跑通过 |
| `Collect_QuickCart_EventPack_OcrCheck` | **500** | **373 / 374**（105 圈 ±1，零方差） | ❌ 恒判负 |

- 选中态文字框在 PC 仅 **65×12 = 780px**，`count: 500` 等于要求 **64% 覆盖率**，而 PC 字形覆盖上限约 48% → **该阈值在 PC 结构性不可达**，不是偶发漏判、也无法靠重试自愈。
- 同帧未选中页签亮像素实测 **0**（店长/剧情/角色三处），选中 373~406 vs 未选中 0 → 分离度极大，阈值取 300 余量充足。
- 300 不是估值，是姊妹节点 `CharacterPack_OcrCheck`（**同 `lower [167,167,165]`、同 ColorMatch 写法**）在 PC 上每日实跑验证过的值。

安卓侧实际能达到多少我这边无从测量，故本 PR **不动 base**，只在 pc 层下调。

## 这不是新判断——是补齐 07-12 那次漏掉的一族

`pc/pipeline/Global.json` 里**完全同构的另一族**页签色核，早在 07-12 就按你的建议全组按 PC 实测下调过（commit a66ff1e「按维护者建议,页签色核count全组按PC实测下调」）：

| 节点族 | Story | Character | Event / Manager / Battleplay / Lifeplay |
| --- | --- | --- | --- |
| `Global_BackToQC_*Cor` base | 200 | 300 | **500** |
| `Global_BackToQC_*Cor` **pc 覆盖（07-12 已有）** | **150** | （未动） | **300** |
| `Collect_QuickCart_*_OcrCheck` base | 200 | 300 | **500** |
| `Collect_QuickCart_*_OcrCheck` pc 覆盖 | （未动） | （未动） | **本 PR 补 300** |

两族的 `lower`、`upper`、ColorMatch 写法、阈值分档**完全一致**，只是当时只覆盖到了 `Global_BackToQC_*Cor`（该族 03-25 归集进 base 时就已存在，只是漏了）。今天走到活动页签，漏掉的那一族就炸了。

也就是说：本 PR 的取值 300 与既有覆盖分毫不差，是把当年的处置补全，而不是新引入一个魔数。今天这一跑里 `GO.QC.战斗玩法页签-色核通过`（已覆盖族）正常通过，可对照。

## 改动

`pc/pipeline/Collect_Launcher.json` 新增 4 个**字段级部分覆盖**（沿用该文件既有写法，6 个 `SelectType_*` 也是只写 roi+expected）：

- `Collect_QuickCart_EventPack_OcrCheck` → `count: 300`（今日实爆点）
- `Collect_QuickCart_{Manager,Battleplay,Lifeplay}Pack_OcrCheck` → `count: 300`

后三个同为 `count: 500` 同族，**PC 上尚未走到过那三个页签，走到必死**，一并预防性下调。

`StoryPack_OcrCheck` 用的是 `count: 200` + `lower [203,203,202]`，属异族，未动。

## 未修的部分（供你定夺）

`SelectType_*` 自环本身无 `max_hit`。本 PR 修 count 后环在第 2 圈即自解（Character 日志里 `count 0`→`406` 的两步舞是设计内行为：首圈复用旧框查空、次圈新框通过），故**未加有界化垫**——该节点每次任务的合法命中数需要按流程实际频次确定，加不好反成误伤源，交你判断是否需要。

## 证据

页签点击成功、但校验腿判负（同一帧可见活动页签已选中 + 卡带排已换）：
![判负帧](https://raw.githubusercontent.com/BebopSpikeSpiegel/MFABD2/evidence-20260824/eventpack_frame_tab_switched_but_check_failed.jpg)
点击前状态（角色页签选中）：
![点击前](https://raw.githubusercontent.com/BebopSpikeSpiegel/MFABD2/evidence-20260824/eventpack_frame_before_click_char_tab.jpg)
[maafw ColorMatcher 全部计数行（123 行，含 Character 406 通过与 Event 373 判负对照）](https://raw.githubusercontent.com/BebopSpikeSpiegel/MFABD2/evidence-20260824/eventpack_maafw_colormatch_counts.log)
