### PR TITLE
Feat/pc-adb-startup-prepare

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,20 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "MFABD2 PC启动准备（独立运行）",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/agent/pc_bootstrap.py",
+            "python": "${workspaceFolder}/.venv/Scripts/python.exe",
+            "pythonArgs": [
+                "-u",
+                "-X",
+                "utf8=1"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "integratedTerminal"
+        },
+        {
             "name": "MFABD2 Agent",
             "type": "debugpy",
             "request": "launch",

--- a/agent/action/__init__.py
+++ b/agent/action/__init__.py
@@ -13,5 +13,6 @@ from .gold_verify import *
 from .arbitrage_result import *
 from .account_save_checker import *
 from .shop_buy_fav_controller import *
+from .startup_prepare import *
 # 如果以后加了别的 action 文件，比如 battle_action.py，就在这里加一行：
 # from .battle_action import *

--- a/agent/action/startup_prepare.py
+++ b/agent/action/startup_prepare.py
@@ -1,0 +1,44 @@
+"""Compatibility adapters for existing StartGame pipeline entry names."""
+
+from maa.agent.agent_server import AgentServer
+from maa.custom_action import CustomAction
+from startup.common import Budget
+from startup.sink import guard
+from utils import mfaalog
+
+
+@AgentServer.custom_action("StartupCheckApp")
+class StartupCheckApp(CustomAction):
+    def run(self, context, argv):
+        result = guard.ensure(context)
+        if result is None:
+            return False
+        kind = context.tasker.controller.info.get("type")
+        # A new/resumed game needs the existing Logo/Loading branch.
+        # Other platforms retain their controller's StartApp path.
+        # PC may have launched in the separate pretask process, so enter the
+        # loading branch (which also recognizes an already-ready home screen).
+        return kind == "adb" and not result.changed
+
+
+@AgentServer.custom_action("StartupRunApp")
+class StartupRunApp(CustomAction):
+    def run(self, context, argv):
+        result = guard.ensure(context)
+        if result is None:
+            return False
+        controller = context.tasker.controller
+        if controller.info.get("type") in ("adb", "win32"):
+            return True
+        # PlayCover continues to use its native StartApp implementation. Native
+        # Android overrides this node with StartApp in its resource layer.
+        try:
+            budget = Budget(mfaalog.info, lambda: context.tasker.stopping)
+            job = controller.post_start_app("com.neowizgames.game.browndust2")
+            while not job.done:
+                budget.pause(0.1)
+            return job.succeeded
+        except Exception as exc:
+            mfaalog.error(f"[启动准备] 控制器启动游戏失败：{exc}")
+            context.tasker.post_stop()
+            return False

--- a/agent/action/startup_prepare.py
+++ b/agent/action/startup_prepare.py
@@ -28,10 +28,10 @@ class StartupRunApp(CustomAction):
         if result is None:
             return False
         controller = context.tasker.controller
-        if controller.info.get("type") in ("adb", "win32"):
+        if controller.info.get("type") in ("adb", "win32", "playcover"):
             return True
-        # PlayCover continues to use its native StartApp implementation. Native
-        # Android overrides this node with StartApp in its resource layer.
+        # PlayCover must already be running to connect; StartApp is unsupported.
+        # Native Android overrides this node with StartApp in its resource layer.
         try:
             budget = Budget(mfaalog.info, lambda: context.tasker.stopping)
             job = controller.post_start_app("com.neowizgames.game.browndust2")

--- a/agent/pc_bootstrap.py
+++ b/agent/pc_bootstrap.py
@@ -45,10 +45,13 @@ def main():
     try:
         from startup.pc import prepare
         from startup.win32 import WindowsAPI
+        from startup.options import PCOptions
 
         budget = Budget(report, lambda: watchdog.host_exited(0))
+        options = PCOptions.from_pretask(sys.argv[1:])
+        report(f"[PC窗口][pretask] 配置：{options.resolution}；最小化={'连接后执行' if options.minimize else '关闭'}")
         with WindowsAPI() as api:
-            prepare(api, budget)
+            prepare(api, budget, options=options)
         budget.success()
         return 0
     except (Cancelled, KeyboardInterrupt):

--- a/agent/pc_bootstrap.py
+++ b/agent/pc_bootstrap.py
@@ -1,0 +1,62 @@
+"""PI pretask entry. No AgentServer, resource loading or controller connection."""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from startup.common import Budget, Cancelled
+
+
+def main():
+    if os.name != "nt":
+        return 0
+    for name in ("stdout", "stderr"):
+        stream = getattr(sys, name)
+        # A GUI pretask may have no inherited console handles.
+        if stream is None:
+            stream = open(os.devnull, "w", encoding="utf-8")
+            setattr(sys, name, stream)
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8")
+    root = Path(__file__).resolve().parent.parent
+    log_dir = root / "debug"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    from logging.handlers import RotatingFileHandler
+
+    logger = logging.getLogger("pc_bootstrap")
+    logger.setLevel(logging.INFO)
+    handler = RotatingFileHandler(log_dir / "pc_bootstrap.log", maxBytes=1024 * 1024, backupCount=2, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+    logger.addHandler(handler)
+
+    def report(message):
+        print(message, flush=True)
+        logger.info(message)
+
+    from utils.host_watchdog import HostWatchdog
+
+    watchdog = HostWatchdog()
+    try:
+        from startup.pc import prepare
+        from startup.win32 import WindowsAPI
+
+        budget = Budget(report, lambda: watchdog.host_exited(0))
+        with WindowsAPI() as api:
+            prepare(api, budget)
+        budget.success()
+        return 0
+    except (Cancelled, KeyboardInterrupt):
+        report("[启动准备] 已取消；游戏和启动器保持运行")
+        return 130
+    except Exception as exc:
+        report(f"[启动准备] 失败：{exc}")
+        return 1
+    finally:
+        watchdog.close()
+        handler.close()
+        logger.removeHandler(handler)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/pc_bootstrap.py
+++ b/agent/pc_bootstrap.py
@@ -5,6 +5,11 @@ import os
 import sys
 from pathlib import Path
 
+# The embedded Windows interpreter uses python310._pth and does not add the
+# script directory to sys.path. Resolve from this file, not the UI's cwd.
+agent_dir = Path(__file__).resolve().parent
+sys.path.insert(0, str(agent_dir))
+
 from startup.common import Budget, Cancelled
 
 

--- a/agent/startup/__init__.py
+++ b/agent/startup/__init__.py
@@ -1,0 +1,1 @@
+"""Startup preparation. Importing this package has no platform or Maa side effects."""

--- a/agent/startup/adb.py
+++ b/agent/startup/adb.py
@@ -1,0 +1,88 @@
+"""Foreground-only ADB preparation; all commands use the bound controller."""
+
+import re
+from enum import Enum
+
+from .common import Prepared, PreparationError
+
+PACKAGE = "com.neowizgames.game.browndust2"
+COMPONENT = re.compile(r"(?<![\w.])([A-Za-z0-9_.]+)/(\.?[A-Za-z0-9_.$]+)(?![\w.$])")
+ERROR = re.compile(r"permission denial|securityexception|error:|not found|can't find|exception", re.I)
+
+
+class Foreground(Enum):
+    GAME = 1
+    OTHER = 2
+    UNKNOWN = 3
+
+
+def parse_foreground(output, markers):
+    if not output or ERROR.search(output):
+        return Foreground.UNKNOWN
+    packages = set()
+    for line in output.splitlines():
+        if any(marker in line for marker in markers):
+            match = COMPONENT.search(line)
+            if match:
+                packages.add(match[1])
+    # Multiple displays/activities with conflicting foreground claims are unknown.
+    if len(packages) != 1:
+        return Foreground.UNKNOWN
+    return Foreground.GAME if packages == {PACKAGE} else Foreground.OTHER
+
+
+def shell(controller, command, budget):
+    budget.check()
+    timeout = max(1, min(5000, int(budget.remaining * 1000)))
+    job = controller.post_shell(command, timeout=timeout)
+    # Do not enqueue another probe behind a stuck shell operation.
+    until = min(budget.deadline, budget.clock() + timeout / 1000)
+    while not job.done:
+        budget.check()
+        if budget.clock() >= until:
+            raise PreparationError("ADB 命令未在限定时间内结束")
+        budget.pause(min(0.1, until - budget.clock()))
+    budget.check()
+    return job.get() if job.succeeded else None
+
+
+def foreground(controller, budget):
+    state = parse_foreground(shell(controller, "dumpsys window windows", budget), ("mCurrentFocus=",))
+    if state != Foreground.UNKNOWN:
+        return state
+    return parse_foreground(
+        shell(controller, "dumpsys activity activities", budget),
+        ("topResumedActivity=", "mResumedActivity:", "ResumedActivity:"),
+    )
+
+
+def prepare(controller, budget):
+    attempted_am = attempted_monkey = changed = False
+    first_probe = True
+    while True:
+        budget.check()
+        budget.phase = "等待安卓游戏进入前台"
+        state = foreground(controller, budget)
+        if state == Foreground.GAME:
+            # A game appearing after an unknown probe/manual intervention also
+            # needs StartGame's loading recognition branch.
+            return Prepared(changed or not first_probe)
+        first_probe = False
+        if state == Foreground.OTHER:
+            if not attempted_am:
+                attempted_am = True
+                output = shell(controller, f"cmd package resolve-activity --brief -a android.intent.action.MAIN -c android.intent.category.LAUNCHER {PACKAGE}", budget)
+                matches = COMPONENT.findall(output or "") if not ERROR.search(output or "") else []
+                components = {f"{pkg}/{activity}" for pkg, activity in matches if pkg == PACKAGE}
+                if len(components) == 1:
+                    changed = True
+                    budget.report("[启动准备] 尝试使用 am start 拉起游戏")
+                    shell(controller, f"am start -n {next(iter(components))}", budget)
+            elif not attempted_monkey:
+                attempted_monkey = True
+                changed = True
+                budget.report("[启动准备] 尝试使用 monkey 拉起游戏")
+                shell(controller, f"monkey -p {PACKAGE} -c android.intent.category.LAUNCHER 1", budget)
+        else:
+            budget.phase = "前台状态未知，等待可确认的窗口或 Activity 信息"
+        budget.pause(2)

--- a/agent/startup/adb.py
+++ b/agent/startup/adb.py
@@ -8,6 +8,7 @@ from .common import Prepared, PreparationError
 PACKAGE = "com.neowizgames.game.browndust2"
 COMPONENT = re.compile(r"(?<![\w.])([A-Za-z0-9_.]+)/(\.?[A-Za-z0-9_.$]+)(?![\w.$])")
 ERROR = re.compile(r"permission denial|securityexception|error:|not found|can't find|exception", re.I)
+COMMAND_ERROR = re.compile(r"^\s*(?:permission denial\b|(?:java\.lang\.)?securityexception\b|error:|exception\b|/system/bin/sh:|sh:)", re.I)
 
 
 class Foreground(Enum):
@@ -17,10 +18,13 @@ class Foreground(Enum):
 
 
 def parse_foreground(output, markers):
-    if not output or ERROR.search(output):
+    if not output:
+        return Foreground.UNKNOWN
+    lines = output.splitlines()
+    if any(COMMAND_ERROR.search(line) for line in lines):
         return Foreground.UNKNOWN
     packages = set()
-    for line in output.splitlines():
+    for line in lines:
         if any(marker in line for marker in markers):
             match = COMPONENT.search(line)
             if match:

--- a/agent/startup/common.py
+++ b/agent/startup/common.py
@@ -1,0 +1,56 @@
+"""Shared deadline and progress reporting for both startup entry points."""
+
+import time
+from dataclasses import dataclass
+
+
+class PreparationError(RuntimeError):
+    pass
+
+
+class Cancelled(PreparationError):
+    pass
+
+
+@dataclass(frozen=True)
+class Prepared:
+    changed: bool = False
+
+
+class Budget:
+    def __init__(self, report, cancelled=lambda: False, *, timeout=300,
+                 clock=time.monotonic, sleep=time.sleep):
+        self.report = report
+        self.cancelled = cancelled
+        self.clock = clock
+        self.sleep = sleep
+        self.started = clock()
+        self.deadline = self.started + timeout
+        self.next_progress = self.started + 30
+        self.phase = "检查游戏状态"
+        report(f"[启动准备] 开始，最多等待 {timeout} 秒")
+
+    @property
+    def remaining(self):
+        return max(0.0, self.deadline - self.clock())
+
+    def check(self):
+        if self.cancelled():
+            raise Cancelled("启动准备已取消")
+        now = self.clock()
+        if now >= self.deadline:
+            raise PreparationError(f"启动准备超时（{self.deadline - self.started:g} 秒）：{self.phase}")
+        if now >= self.next_progress:
+            self.report(f"[启动准备] 已等待 {int(now - self.started)} 秒：{self.phase}")
+            self.next_progress += (int((now - self.next_progress) // 30) + 1) * 30
+
+    def pause(self, seconds):
+        until = min(self.clock() + seconds, self.deadline)
+        while self.clock() < until:
+            self.check()
+            self.sleep(min(0.1, until - self.clock()))
+        self.check()
+
+    def success(self):
+        self.check()
+        self.report(f"[启动准备] 完成（{self.clock() - self.started:.1f} 秒）")

--- a/agent/startup/common.py
+++ b/agent/startup/common.py
@@ -52,5 +52,8 @@ class Budget:
         self.check()
 
     def success(self):
-        self.check()
+        # Preparation has already confirmed readiness. Reporting must not turn
+        # that result into a timeout, but cancellation still stops the task.
+        if self.cancelled():
+            raise Cancelled("启动准备已取消")
         self.report(f"[启动准备] 完成（{self.clock() - self.started:.1f} 秒）")

--- a/agent/startup/guard.py
+++ b/agent/startup/guard.py
@@ -16,7 +16,6 @@ class StartupGuard:
         self.pc_prepare = pc_prepare or self._pc_prepare
         self.tasks = OrderedDict()
         self.failures = {}
-        self.identity_failure = None
 
     @staticmethod
     def _pc_prepare(controller, info, budget, options):
@@ -52,8 +51,6 @@ class StartupGuard:
         tasker = context.tasker
         key = None
         try:
-            if self.identity_failure:
-                raise PreparationError(self.identity_failure)
             controller = tasker.controller
             info = controller.info
             kind = info.get("type")
@@ -86,11 +83,12 @@ class StartupGuard:
             self.stop(tasker)
             return None
         except Exception as exc:
-            reason = str(exc)
-            if key is None:
-                self.identity_failure = reason
-            else:
+            reason = str(exc) or type(exc).__name__
+            if key is not None:
                 self.failures[key] = reason
-            self.error(f"[启动准备] {reason}；本会话后续任务将停止执行，请修复后重新启动软件")
+                self.error(f"[启动准备] {reason}；本会话该控制器的后续任务将停止执行，请修复后重新启动软件")
+            else:
+                # A transient identity query cannot poison unrelated devices.
+                self.error(f"[启动准备] {reason}；本任务已停止，请检查控制器连接后重试")
             self.stop(tasker)
             return None

--- a/agent/startup/guard.py
+++ b/agent/startup/guard.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from . import adb
 from .common import Budget, Cancelled, Prepared, PreparationError
+from .options import PCOptions
 
 
 class StartupGuard:
@@ -18,7 +19,7 @@ class StartupGuard:
         self.identity_failure = None
 
     @staticmethod
-    def _pc_prepare(controller, info, budget):
+    def _pc_prepare(controller, info, budget, options):
         from .pc import prepare
         from .win32 import WindowsAPI
 
@@ -28,7 +29,19 @@ class StartupGuard:
         if not isinstance(hwnd, int) or not hwnd:
             raise PreparationError("Win32 控制器未提供有效的窗口句柄")
         with WindowsAPI() as api:
-            return prepare(api, budget, hwnd=hwnd)
+            if not options.minimize and api.pseudo_minimized(hwnd):
+                budget.check()
+                # Let the framework restore its own saved extended styles.
+                job = controller.post_inactive()
+                until = min(budget.deadline, budget.clock() + 5)
+                while not job.done:
+                    budget.check()
+                    if budget.clock() >= until:
+                        raise PreparationError("框架恢复普通窗口超时")
+                    budget.pause(0.1)
+                if not job.succeeded:
+                    raise PreparationError("框架无法恢复普通窗口")
+            return prepare(api, budget, hwnd=hwnd, options=options)
 
     @staticmethod
     def stop(tasker):
@@ -61,7 +74,8 @@ class StartupGuard:
             if kind == "adb":
                 result = self.adb_prepare(controller, budget)
             else:
-                result = self.pc_prepare(controller, info, budget)
+                options = PCOptions.from_context(context)
+                result = self.pc_prepare(controller, info, budget, options)
             budget.success()
             self.tasks[task_key] = result
             if len(self.tasks) > 256:

--- a/agent/startup/guard.py
+++ b/agent/startup/guard.py
@@ -1,0 +1,82 @@
+"""Per-task gate with failures retained for the lifetime of the agent session."""
+
+from collections import OrderedDict
+
+from . import adb
+from .common import Budget, Cancelled, Prepared, PreparationError
+
+
+class StartupGuard:
+    def __init__(self, report, error, *, budget_factory=Budget, adb_prepare=adb.prepare, pc_prepare=None):
+        self.report = report
+        self.error = error
+        self.budget_factory = budget_factory
+        self.adb_prepare = adb_prepare
+        self.pc_prepare = pc_prepare or self._pc_prepare
+        self.tasks = OrderedDict()
+        self.failures = {}
+        self.identity_failure = None
+
+    @staticmethod
+    def _pc_prepare(controller, info, budget):
+        from .pc import prepare
+        from .win32 import WindowsAPI
+
+        hwnd = info.get("hwnd")
+        if isinstance(hwnd, str):
+            hwnd = int(hwnd, 0)
+        if not isinstance(hwnd, int) or not hwnd:
+            raise PreparationError("Win32 控制器未提供有效的窗口句柄")
+        with WindowsAPI() as api:
+            return prepare(api, budget, hwnd=hwnd)
+
+    @staticmethod
+    def stop(tasker):
+        # Waiting here deadlocks the task whose callback is currently executing.
+        tasker.post_stop()
+
+    def ensure(self, context, task_id=None):
+        tasker = context.tasker
+        key = None
+        try:
+            if self.identity_failure:
+                raise PreparationError(self.identity_failure)
+            controller = tasker.controller
+            info = controller.info
+            kind = info.get("type")
+            if kind not in ("adb", "win32"):
+                return Prepared()
+            uuid = controller.uuid
+            if not uuid:
+                raise PreparationError("无法取得控制器的稳定身份")
+            key = (kind, uuid)
+            if key in self.failures:
+                raise PreparationError(self.failures[key])
+            if task_id is None:
+                task_id = context.get_task_job().job_id
+            task_key = (key, task_id)
+            if task_key in self.tasks:
+                return self.tasks[task_key]
+            budget = self.budget_factory(self.report, lambda: tasker.stopping)
+            if kind == "adb":
+                result = self.adb_prepare(controller, budget)
+            else:
+                result = self.pc_prepare(controller, info, budget)
+            budget.success()
+            self.tasks[task_key] = result
+            if len(self.tasks) > 256:
+                self.tasks.popitem(last=False)
+            return result
+        except Cancelled as exc:
+            self.report(f"[启动准备] {exc}")
+            self.stop(tasker)
+            return None
+        except Exception as exc:
+            reason = str(exc)
+            if key is None:
+                self.identity_failure = reason
+            else:
+                self.failures[key] = reason
+            self.error(f"[启动准备] {reason}；本会话后续任务将停止执行，请修复后重新启动软件")
+            self.stop(tasker)
+            return None

--- a/agent/startup/maa_compat.py
+++ b/agent/startup/maa_compat.py
@@ -1,0 +1,21 @@
+"""Missing ctypes signatures in MaaFw 5.12.2's public post_shell binding."""
+
+import ctypes
+
+
+def ensure_shell_bindings():
+    from maa.define import MaaBool, MaaControllerHandle, MaaCtrlId, MaaStringBufferHandle
+    from maa.library import Library
+
+    library = Library.framework()
+    # Signatures are from v5.12.2 include/MaaFramework/Instance/MaaController.h.
+    # Leave a future SDK's own declarations intact. No library files are edited.
+    signatures = (
+        ("MaaControllerPostShell", MaaCtrlId, [MaaControllerHandle, ctypes.c_char_p, ctypes.c_int64]),
+        ("MaaControllerGetShellOutput", MaaBool, [MaaControllerHandle, MaaStringBufferHandle]),
+    )
+    for name, result, args in signatures:
+        function = getattr(library, name)
+        if function.argtypes is None:
+            function.restype = result
+            function.argtypes = args

--- a/agent/startup/options.py
+++ b/agent/startup/options.py
@@ -1,0 +1,54 @@
+"""PC options shared by PI pretask arguments and task-local pipeline attach."""
+
+import json
+from dataclasses import dataclass
+
+from .common import PreparationError
+
+NODE = "StartGame_PCWindowOptions"
+RESOLUTION_OPTION = "PC窗口分辨率"
+MINIMIZE_OPTION = "PC启动最小化"
+RESOLUTIONS = {"720p": (1280, 720), "1080p": (1920, 1080)}
+
+
+@dataclass(frozen=True)
+class PCOptions:
+    resolution: str = "720p"
+    minimize: bool = False
+
+    def __post_init__(self):
+        if self.resolution not in RESOLUTIONS:
+            raise PreparationError(f"不支持的 PC 窗口分辨率：{self.resolution}")
+        if not isinstance(self.minimize, bool):
+            raise PreparationError("PC 最小化配置必须为布尔值")
+
+    @property
+    def target(self):
+        return RESOLUTIONS[self.resolution]
+
+    @classmethod
+    def from_pretask(cls, arguments):
+        if not arguments:
+            return cls()
+        if len(arguments) != 1:
+            raise PreparationError("PC pretask 需要一个选项 JSON 参数")
+        try:
+            values = json.loads(arguments[0])
+            if not isinstance(values, dict):
+                raise ValueError("选项不是对象")
+            minimized = values.get(MINIMIZE_OPTION, "No")
+            if minimized not in ("Yes", "No"):
+                raise ValueError("最小化选项必须为 Yes/No")
+            return cls(values.get(RESOLUTION_OPTION, "720p"), minimized == "Yes")
+        except (ValueError, TypeError) as exc:
+            raise PreparationError(f"PC pretask 选项无效：{exc}") from exc
+
+    @classmethod
+    def from_context(cls, context):
+        node = context.get_node_object(NODE)
+        if node is None:
+            raise PreparationError("缺少 PC 窗口配置节点，请更新 base 资源")
+        values = node.attach
+        if not isinstance(values, dict):
+            raise PreparationError("PC 窗口配置 attach 不是对象")
+        return cls(values.get("resolution", "720p"), values.get("minimize", False))

--- a/agent/startup/pc.py
+++ b/agent/startup/pc.py
@@ -1,0 +1,61 @@
+"""PC state machine, independent of native calls for offline verification."""
+
+from .common import Prepared, PreparationError
+
+TARGET = (1280, 720)
+
+
+def resize(api, hwnd, budget):
+    until = min(budget.deadline, budget.clock() + 10)
+    toggled = False
+    for _ in range(5):
+        budget.check()
+        if budget.clock() >= until:
+            break
+        if not api.is_game(hwnd):
+            raise PreparationError("绑定的游戏窗口已失效，请重新连接")
+        if api.restore(hwnd) is False:
+            budget.pause(min(0.2, until - budget.clock()))
+            continue
+        if api.fullscreen(hwnd):
+            if not toggled:
+                api.exit_fullscreen(hwnd)
+                toggled = True
+            budget.pause(min(1, until - budget.clock()))
+            continue
+        if api.client_size(hwnd) == TARGET:
+            return
+        api.resize_client(hwnd, TARGET)
+        budget.pause(min(0.5, until - budget.clock()))
+        if api.is_game(hwnd) and not api.fullscreen(hwnd) and api.client_size(hwnd) == TARGET:
+            return
+    raise PreparationError("无法将游戏客户区调整为 1280×720，请手动 Alt+Enter 切回窗口模式后重试")
+
+
+def prepare(api, budget, hwnd=None):
+    # A connected controller must keep its original HWND; never silently rebind.
+    if hwnd is not None:
+        budget.phase = "校正绑定的 PC 游戏窗口"
+        resize(api, hwnd, budget)
+        return Prepared()
+    launched = False
+    last_dialogs = None
+    while True:
+        budget.check()
+        windows, running, dialogs = api.scan()
+        if len(windows) > 1:
+            raise PreparationError("检测到多个棕色尘埃2游戏窗口，请保留需要连接的一个")
+        if windows:
+            budget.phase = "校正 PC 游戏窗口"
+            resize(api, windows[0], budget)
+            return Prepared(launched)
+        if dialogs != last_dialogs:
+            if dialogs:
+                budget.report(f"[启动准备] 启动器窗口：{', '.join(dialogs)}；继续观察，不自动点击弹框")
+            last_dialogs = dialogs
+        if not running and not launched:
+            api.launch()
+            launched = True
+            budget.report("[启动准备] 已调用官方启动器")
+        budget.phase = "等待启动器更新并交接游戏主窗口"
+        budget.pause(2)

--- a/agent/startup/pc.py
+++ b/agent/startup/pc.py
@@ -9,7 +9,8 @@ TARGET = (1280, 720)
 def resize(api, hwnd, budget, target=TARGET):
     until = min(budget.deadline, budget.clock() + 10)
     toggled = False
-    for _ in range(5):
+    original_size = None
+    while True:
         budget.check()
         if budget.clock() >= until:
             break
@@ -24,12 +25,15 @@ def resize(api, hwnd, budget, target=TARGET):
                 toggled = True
             budget.pause(min(1, until - budget.clock()))
             continue
-        if api.client_size(hwnd) == target:
-            return
+        size = api.client_size(hwnd)
+        if original_size is None:
+            original_size = size
+        if size == target:
+            return original_size
         api.resize_client(hwnd, target)
         budget.pause(min(0.5, until - budget.clock()))
         if api.is_game(hwnd) and not api.fullscreen(hwnd) and api.client_size(hwnd) == target:
-            return
+            return original_size
     raise PreparationError(f"无法将游戏客户区调整为 {target[0]}×{target[1]}，请手动 Alt+Enter 切回窗口模式后重试")
 
 
@@ -41,9 +45,12 @@ def apply_window_options(api, hwnd, budget, options, source):
     was_minimized = api.minimized(hwnd)
     was_fullscreen = api.fullscreen(hwnd)
     if not options.minimize and api.pseudo_minimized(hwnd):
-        raise PreparationError("游戏窗口仍由旧控制器保持透明，请停止旧任务后重新连接")
-    if not (options.minimize and was_minimized and before == options.target):
-        resize(api, hwnd, budget, options.target)
+        raise PreparationError("游戏窗口仍保持透明，请先关闭其他控制端；若旧控制端已退出，请重启游戏后重新连接")
+    # Iconic windows can report 0x0. Measure after restoring instead of
+    # treating the iconic size as a real resolution or an optimization hint.
+    restored_size = resize(api, hwnd, budget, options.target)
+    if was_minimized:
+        before = restored_size
     actual = api.client_size(hwnd)
     # Measure and confirm the physical client area before Windows minimizes it.
     if actual != options.target:

--- a/agent/startup/pc.py
+++ b/agent/startup/pc.py
@@ -1,11 +1,12 @@
 """PC state machine, independent of native calls for offline verification."""
 
 from .common import Prepared, PreparationError
+from .options import PCOptions
 
 TARGET = (1280, 720)
 
 
-def resize(api, hwnd, budget):
+def resize(api, hwnd, budget, target=TARGET):
     until = min(budget.deadline, budget.clock() + 10)
     toggled = False
     for _ in range(5):
@@ -23,20 +24,53 @@ def resize(api, hwnd, budget):
                 toggled = True
             budget.pause(min(1, until - budget.clock()))
             continue
-        if api.client_size(hwnd) == TARGET:
+        if api.client_size(hwnd) == target:
             return
-        api.resize_client(hwnd, TARGET)
+        api.resize_client(hwnd, target)
         budget.pause(min(0.5, until - budget.clock()))
-        if api.is_game(hwnd) and not api.fullscreen(hwnd) and api.client_size(hwnd) == TARGET:
+        if api.is_game(hwnd) and not api.fullscreen(hwnd) and api.client_size(hwnd) == target:
             return
-    raise PreparationError("无法将游戏客户区调整为 1280×720，请手动 Alt+Enter 切回窗口模式后重试")
+    raise PreparationError(f"无法将游戏客户区调整为 {target[0]}×{target[1]}，请手动 Alt+Enter 切回窗口模式后重试")
 
 
-def prepare(api, budget, hwnd=None):
+def apply_window_options(api, hwnd, budget, options, source):
+    budget.check()
+    if not api.is_game(hwnd):
+        raise PreparationError("绑定的游戏窗口已失效，请重新连接")
+    before = api.client_size(hwnd)
+    was_minimized = api.minimized(hwnd)
+    was_fullscreen = api.fullscreen(hwnd)
+    if not options.minimize and api.pseudo_minimized(hwnd):
+        raise PreparationError("游戏窗口仍由旧控制器保持透明，请停止旧任务后重新连接")
+    if not (options.minimize and was_minimized and before == options.target):
+        resize(api, hwnd, budget, options.target)
+    actual = api.client_size(hwnd)
+    # Measure and confirm the physical client area before Windows minimizes it.
+    if actual != options.target:
+        raise PreparationError(f"PC 客户区回读不符：期望 {options.target}，实际 {actual}")
+    if options.minimize:
+        budget.check()
+        if not api.minimized(hwnd) and not api.pseudo_minimized(hwnd):
+            api.minimize(hwnd)
+        until = min(budget.deadline, budget.clock() + 2)
+        while not (api.minimized(hwnd) or api.pseudo_minimized(hwnd)):
+            budget.check()
+            if not api.is_game(hwnd) or budget.clock() >= until:
+                raise PreparationError("2 秒内未确认 PC 窗口最小化状态")
+            budget.pause(0.1)
+    resized = "已调整" if before != actual else "无需调整"
+    restored = "；已退出全屏" if was_fullscreen else "；已还原窗口" if was_minimized and not options.minimize else ""
+    mode = "最小化（由框架维持后台渲染）" if options.minimize else "普通窗口"
+    budget.report(f"[PC窗口][{source}] 分辨率 {before[0]}×{before[1]} → {actual[0]}×{actual[1]}（{resized}{restored}）；{mode}")
+
+
+def prepare(api, budget, hwnd=None, options=None):
+    options = options or PCOptions()
+
     # A connected controller must keep its original HWND; never silently rebind.
     if hwnd is not None:
         budget.phase = "校正绑定的 PC 游戏窗口"
-        resize(api, hwnd, budget)
+        apply_window_options(api, hwnd, budget, options, "sink")
         return Prepared()
     launched = False
     last_dialogs = None
@@ -47,7 +81,12 @@ def prepare(api, budget, hwnd=None):
             raise PreparationError("检测到多个棕色尘埃2游戏窗口，请保留需要连接的一个")
         if windows:
             budget.phase = "校正 PC 游戏窗口"
-            resize(api, windows[0], budget)
+            # Keep the window restored for controller connection. Apply the
+            # requested minimized mode only after connection, in the task sink.
+            connection_options = PCOptions(options.resolution, minimize=False)
+            apply_window_options(api, windows[0], budget, connection_options, "pretask")
+            if options.minimize:
+                budget.report("[PC窗口][pretask] 最小化已留待连接完成后、任务开始前执行")
             return Prepared(launched)
         if dialogs != last_dialogs:
             if dialogs:

--- a/agent/startup/sink.py
+++ b/agent/startup/sink.py
@@ -1,0 +1,25 @@
+"""Synchronous Context events run before the first business screenshot."""
+
+from maa.agent.agent_server import AgentServer
+from maa.context import ContextEventSink
+from maa.event_sink import NotificationType
+from utils import mfaalog
+
+from .guard import StartupGuard
+from . import adb
+from .maa_compat import ensure_shell_bindings
+
+
+def prepare_adb(controller, budget):
+    ensure_shell_bindings()
+    return adb.prepare(controller, budget)
+
+
+guard = StartupGuard(mfaalog.info, mfaalog.error, adb_prepare=prepare_adb)
+
+
+@AgentServer.context_sink()
+class StartupSink(ContextEventSink):
+    def on_node_pipeline_node(self, context, noti_type, detail):
+        if noti_type == NotificationType.Starting:
+            guard.ensure(context, detail.task_id)

--- a/agent/startup/sink.py
+++ b/agent/startup/sink.py
@@ -17,9 +17,14 @@ def prepare_adb(controller, budget):
 
 guard = StartupGuard(mfaalog.info, mfaalog.error, adb_prepare=prepare_adb)
 
+# MaaFw 5.12.2's context-sink decorator does not initialize its ctypes binding.
+# Initialize explicitly instead of depending on unrelated action import order.
+AgentServer._set_api_properties()
 
 @AgentServer.context_sink()
 class StartupSink(ContextEventSink):
     def on_node_pipeline_node(self, context, noti_type, detail):
         if noti_type == NotificationType.Starting:
-            guard.ensure(context, detail.task_id)
+            # Nested run_task events have a new task id; their cloned Context
+            # still identifies the top-level task that owns this preparation.
+            guard.ensure(context)

--- a/agent/startup/win32.py
+++ b/agent/startup/win32.py
@@ -45,6 +45,7 @@ class WindowsAPI:
             (self.user, "SetWindowPos", W.BOOL, [W.HWND, W.HWND, C.c_int, C.c_int, C.c_int, C.c_int, W.UINT]),
             (self.user, "PostMessageW", W.BOOL, [W.HWND, W.UINT, W.WPARAM, W.LPARAM]),
             (self.user, "GetWindowLongW", W.LONG, [W.HWND, C.c_int]),
+            (self.user, "GetLayeredWindowAttributes", W.BOOL, [W.HWND, C.POINTER(W.DWORD), C.POINTER(W.BYTE), C.POINTER(W.DWORD)]),
             (self.user, "SetThreadDpiAwarenessContext", W.HANDLE, [W.HANDLE]),
             (self.kernel, "OpenProcess", W.HANDLE, [W.DWORD, W.BOOL, W.DWORD]),
             (self.kernel, "CloseHandle", W.BOOL, [W.HANDLE]),
@@ -161,6 +162,22 @@ class WindowsAPI:
             self.user.ShowWindowAsync(hwnd, 9)
             return False
         return True
+
+    def minimized(self, hwnd):
+        return bool(self.user.IsIconic(hwnd))
+
+    def pseudo_minimized(self, hwnd):
+        style = self.user.GetWindowLongW(hwnd, -20)
+        if style & 0x80020 != 0x80020:
+            return False
+        color, alpha, flags = W.DWORD(), W.BYTE(), W.DWORD()
+        return bool(self.user.GetLayeredWindowAttributes(hwnd, C.byref(color), C.byref(alpha), C.byref(flags))
+                    and flags.value & 2 and alpha.value == 0)
+
+    def minimize(self, hwnd):
+        if not self.user.IsWindow(hwnd):
+            raise PreparationError("最小化前游戏窗口已失效")
+        self.user.ShowWindowAsync(hwnd, 6)
 
     def fullscreen(self, hwnd):
         return not bool(self.user.GetWindowLongW(hwnd, -16) & 0x00C00000)

--- a/agent/startup/win32.py
+++ b/agent/startup/win32.py
@@ -1,0 +1,190 @@
+"""Small native adapter. Imported only for actual Win32 preparation."""
+
+import ctypes as C
+import ntpath
+import os
+import re
+from ctypes import wintypes as W
+
+from .common import PreparationError
+
+GAME_EXE = "browndust ii.exe"
+STARTER_EXE = "browndust2starter.exe"
+GAME_CLASS = "UnityWndClass"
+GAME_TITLE = "BrownDust II"
+GAME_URI = "browndust2:games/10000001?usn=0"
+
+
+class ProcessEntry(C.Structure):
+    _fields_ = [("dwSize", W.DWORD), ("cntUsage", W.DWORD),
+                ("th32ProcessID", W.DWORD), ("th32DefaultHeapID", C.c_size_t),
+                ("th32ModuleID", W.DWORD), ("cntThreads", W.DWORD),
+                ("th32ParentProcessID", W.DWORD), ("pcPriClassBase", W.LONG),
+                ("dwFlags", W.DWORD), ("szExeFile", W.WCHAR * 260)]
+
+
+class WindowsAPI:
+    def __init__(self):
+        if os.name != "nt":
+            raise PreparationError("PC 启动准备仅支持 Windows")
+        self.user = C.WinDLL("user32", use_last_error=True)
+        self.kernel = C.WinDLL("kernel32", use_last_error=True)
+        self.enum_callback = C.WINFUNCTYPE(W.BOOL, W.HWND, W.LPARAM)
+        signatures = [
+            (self.user, "EnumWindows", W.BOOL, [self.enum_callback, W.LPARAM]),
+            (self.user, "IsWindow", W.BOOL, [W.HWND]),
+            (self.user, "IsWindowVisible", W.BOOL, [W.HWND]),
+            (self.user, "IsIconic", W.BOOL, [W.HWND]),
+            (self.user, "IsZoomed", W.BOOL, [W.HWND]),
+            (self.user, "GetWindowThreadProcessId", W.DWORD, [W.HWND, C.POINTER(W.DWORD)]),
+            (self.user, "GetClassNameW", C.c_int, [W.HWND, W.LPWSTR, C.c_int]),
+            (self.user, "GetWindowTextW", C.c_int, [W.HWND, W.LPWSTR, C.c_int]),
+            (self.user, "GetClientRect", W.BOOL, [W.HWND, C.POINTER(W.RECT)]),
+            (self.user, "GetWindowRect", W.BOOL, [W.HWND, C.POINTER(W.RECT)]),
+            (self.user, "ShowWindowAsync", W.BOOL, [W.HWND, C.c_int]),
+            (self.user, "SetWindowPos", W.BOOL, [W.HWND, W.HWND, C.c_int, C.c_int, C.c_int, C.c_int, W.UINT]),
+            (self.user, "PostMessageW", W.BOOL, [W.HWND, W.UINT, W.WPARAM, W.LPARAM]),
+            (self.user, "GetWindowLongW", W.LONG, [W.HWND, C.c_int]),
+            (self.user, "SetThreadDpiAwarenessContext", W.HANDLE, [W.HANDLE]),
+            (self.kernel, "OpenProcess", W.HANDLE, [W.DWORD, W.BOOL, W.DWORD]),
+            (self.kernel, "CloseHandle", W.BOOL, [W.HANDLE]),
+            (self.kernel, "QueryFullProcessImageNameW", W.BOOL, [W.HANDLE, W.DWORD, W.LPWSTR, C.POINTER(W.DWORD)]),
+            (self.kernel, "CreateToolhelp32Snapshot", W.HANDLE, [W.DWORD, W.DWORD]),
+            (self.kernel, "Process32FirstW", W.BOOL, [W.HANDLE, C.POINTER(ProcessEntry)]),
+            (self.kernel, "Process32NextW", W.BOOL, [W.HANDLE, C.POINTER(ProcessEntry)]),
+        ]
+        for dll, name, result, args in signatures:
+            func = getattr(dll, name)
+            func.restype, func.argtypes = result, args
+        self.previous_dpi = None
+
+    def __enter__(self):
+        # Coordinate calls on this thread use physical pixels, without changing
+        # the UI/controller process or the awareness of other agent threads.
+        self.previous_dpi = self.user.SetThreadDpiAwarenessContext(C.c_void_p(-4))
+        if not self.previous_dpi:
+            raise PreparationError("无法启用物理像素坐标模式")
+        return self
+
+    def __exit__(self, *_):
+        if self.previous_dpi:
+            self.user.SetThreadDpiAwarenessContext(self.previous_dpi)
+            self.previous_dpi = None
+
+    def _processes(self):
+        snapshot = self.kernel.CreateToolhelp32Snapshot(2, 0)
+        if snapshot == C.c_void_p(-1).value:
+            raise C.WinError(C.get_last_error())
+        processes = {}
+        try:
+            entry = ProcessEntry()
+            entry.dwSize = C.sizeof(entry)
+            more = self.kernel.Process32FirstW(snapshot, C.byref(entry))
+            if not more:
+                raise C.WinError(C.get_last_error())
+            while more:
+                processes[entry.th32ProcessID] = entry.szExeFile.lower()
+                more = self.kernel.Process32NextW(snapshot, C.byref(entry))
+        finally:
+            self.kernel.CloseHandle(snapshot)
+        return processes
+
+    def process_path(self, pid):
+        handle = self.kernel.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return ""
+        try:
+            buf, size = C.create_unicode_buffer(32768), W.DWORD(32768)
+            if self.kernel.QueryFullProcessImageNameW(handle, 0, buf, C.byref(size)):
+                return buf.value
+            return ""
+        finally:
+            self.kernel.CloseHandle(handle)
+
+    def _pid(self, hwnd):
+        pid = W.DWORD()
+        self.user.GetWindowThreadProcessId(hwnd, C.byref(pid))
+        return pid.value
+
+    def _class(self, hwnd):
+        buf = C.create_unicode_buffer(256)
+        self.user.GetClassNameW(hwnd, buf, len(buf))
+        return buf.value
+
+    def _title(self, hwnd):
+        buf = C.create_unicode_buffer(512)
+        self.user.GetWindowTextW(hwnd, buf, len(buf))
+        return buf.value
+
+    def is_game(self, hwnd):
+        return bool(self.user.IsWindow(hwnd) and self._class(hwnd) == GAME_CLASS
+                    and ntpath.basename(self.process_path(self._pid(hwnd))).lower() == GAME_EXE)
+
+    def scan(self):
+        processes = self._processes()
+        games, dialogs = [], []
+
+        @self.enum_callback
+        def collect(hwnd, _):
+            if not self.user.IsWindowVisible(hwnd):
+                return True
+            exe = processes.get(self._pid(hwnd), "")
+            # Match the UI's main-window filter before handing control back;
+            # a transient Unity window with no final title is not connectable.
+            if exe == GAME_EXE and self.is_game(hwnd) and self._title(hwnd) == GAME_TITLE:
+                games.append(hwnd)
+            elif exe == STARTER_EXE:
+                dialogs.append(self._title(hwnd) or self._class(hwnd))
+            return True
+
+        if not self.user.EnumWindows(collect, 0):
+            raise C.WinError(C.get_last_error())
+        running = any(exe in (GAME_EXE, STARTER_EXE) for exe in processes.values())
+        return games, running, tuple(sorted(set(dialogs)))
+
+    def launch(self):
+        import winreg
+
+        try:
+            with winreg.OpenKey(winreg.HKEY_CLASSES_ROOT, r"browndust2\shell\open\command") as key:
+                command = winreg.QueryValueEx(key, "")[0]
+        except OSError as exc:
+            raise PreparationError("未找到官方 browndust2 启动入口，请先安装 PC 独立版并手动启动一次") from exc
+        match = re.match(r'^\s*(?:"([^"]+)"|(\S+))', os.path.expandvars(command))
+        executable = next((part for part in match.groups() if part), "") if match else ""
+        if ntpath.basename(executable).lower() != STARTER_EXE or not os.path.isfile(executable):
+            raise PreparationError("官方启动器注册路径无效，请修复 PC 独立版安装")
+        os.startfile(GAME_URI)
+
+    def restore(self, hwnd):
+        if self.user.IsIconic(hwnd) or self.user.IsZoomed(hwnd):
+            self.user.ShowWindowAsync(hwnd, 9)
+            return False
+        return True
+
+    def fullscreen(self, hwnd):
+        return not bool(self.user.GetWindowLongW(hwnd, -16) & 0x00C00000)
+
+    def client_size(self, hwnd):
+        rect = W.RECT()
+        if not self.user.GetClientRect(hwnd, C.byref(rect)):
+            raise C.WinError(C.get_last_error())
+        return rect.right - rect.left, rect.bottom - rect.top
+
+    def resize_client(self, hwnd, target):
+        width, height = self.client_size(hwnd)
+        rect = W.RECT()
+        if not self.user.GetWindowRect(hwnd, C.byref(rect)):
+            raise C.WinError(C.get_last_error())
+        outer_width = rect.right - rect.left + target[0] - width
+        outer_height = rect.bottom - rect.top + target[1] - height
+        # Async positioning avoids blocking on the game's UI thread.
+        if not self.user.SetWindowPos(hwnd, None, 0, 0, outer_width, outer_height, 0x4000 | 0x16):
+            raise C.WinError(C.get_last_error())
+
+    def exit_fullscreen(self, hwnd):
+        # Unity's Alt+Enter handling; never rewrite Unity window styles.
+        for msg, param in ((0x104, 1 | (0x1C << 16) | (1 << 29)),
+                           (0x105, 1 | (0x1C << 16) | (1 << 29) | (3 << 30))):
+            if not self.user.PostMessageW(hwnd, msg, 0x0D, param):
+                raise C.WinError(C.get_last_error())

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -16,12 +16,28 @@
             "type": "Win32",
             "win32": {
                 "class_regex": "UnityWndClass",
+                "window_regex": "^BrownDust II$",
                 "screencap": "FramePool",
                 "mouse": "PostMessageWithWindowPos",
                 "keyboard": "PostMessageWithWindowPos"
             },
             "permission_required": true,
             "display_short_side": 720
+        }
+    ],
+    "pretask": [
+        {
+            "name": "PC游戏启动准备",
+            "controller": [
+                "PC客户端"
+            ],
+            "exec": "../../../.venv/Scripts/python.exe",
+            "args": [
+                "-u",
+                "-X",
+                "utf8=1",
+                "../../../agent/pc_bootstrap.py"
+            ]
         }
     ],
     "resource": [

--- a/assets/interface.json
+++ b/assets/interface.json
@@ -37,6 +37,10 @@
                 "-X",
                 "utf8=1",
                 "../../../agent/pc_bootstrap.py"
+            ],
+            "option": [
+                "PC窗口分辨率",
+                "PC启动最小化"
             ]
         }
     ],
@@ -71,6 +75,8 @@
         }
     ],
     "global_option": [
+        "PC窗口分辨率",
+        "PC启动最小化",
         "前置助手",
         "存档名称"
     ],
@@ -327,6 +333,70 @@
         }
     ],
     "option": {
+        "PC窗口分辨率": {
+            "type": "select",
+            "label": "PC窗口分辨率",
+            "controller": [
+                "PC客户端"
+            ],
+            "default_case": "720p",
+            "description": "调整游戏窗口内部画面的尺寸：720p 为 1280×720，1080p 为 1920×1080。<br>识别坐标仍由框架按 720p 缩放。下一个任务开始时生效，无需重新连接。",
+            "cases": [
+                {
+                    "name": "720p",
+                    "label": "720p（1280×720）",
+                    "pipeline_override": {
+                        "StartGame_PCWindowOptions": {
+                            "attach": {
+                                "resolution": "720p"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "1080p",
+                    "label": "1080p（1920×1080）",
+                    "pipeline_override": {
+                        "StartGame_PCWindowOptions": {
+                            "attach": {
+                                "resolution": "1080p"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "PC启动最小化": {
+            "type": "switch",
+            "label": "PC启动后最小化",
+            "controller": [
+                "PC客户端"
+            ],
+            "default_case": "No",
+            "description": "连接完成后，每个任务开始时先调整分辨率，再最小化游戏，减少后台操作时窗口跳动的干扰。连接前保持普通窗口。<br>框架保持后台渲染；点击任务栏中的游戏可恢复查看。任务结束或停止时，框架可能自动恢复窗口。下一个任务开始时生效。",
+            "cases": [
+                {
+                    "name": "No",
+                    "pipeline_override": {
+                        "StartGame_PCWindowOptions": {
+                            "attach": {
+                                "minimize": false
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "Yes",
+                    "pipeline_override": {
+                        "StartGame_PCWindowOptions": {
+                            "attach": {
+                                "minimize": true
+                            }
+                        }
+                    }
+                }
+            ]
+        },
         "日常-强制只跑指定子项": {
             "label": "[手动开关]-强制只跑指定子项",
             "type": "switch",
@@ -1662,7 +1732,9 @@
                 {
                     "name": "Yes",
                     "pipeline_override": {},
-                    "option": ["亲密度谈心等级筛选"]
+                    "option": [
+                        "亲密度谈心等级筛选"
+                    ]
                 },
                 {
                     "name": "No",
@@ -1683,7 +1755,9 @@
                     "name": "Lv<10",
                     "pipeline_override": {
                         "Sub_Intimacy_LV": {
-                            "expected": ["^[1-9]$"]
+                            "expected": [
+                                "^[1-9]$"
+                            ]
                         }
                     }
                 },
@@ -1691,7 +1765,9 @@
                     "name": "Lv<15",
                     "pipeline_override": {
                         "Sub_Intimacy_LV": {
-                            "expected": ["^([1-9]|1[0-4])$"]
+                            "expected": [
+                                "^([1-9]|1[0-4])$"
+                            ]
                         }
                     }
                 },
@@ -1699,7 +1775,9 @@
                     "name": "Lv<20",
                     "pipeline_override": {
                         "Sub_Intimacy_LV": {
-                            "expected": ["^([1-9]|1[0-9])$"]
+                            "expected": [
+                                "^([1-9]|1[0-9])$"
+                            ]
                         }
                     }
                 }

--- a/assets/resource/android_native/pipeline/StartGame.json
+++ b/assets/resource/android_native/pipeline/StartGame.json
@@ -14,6 +14,7 @@
     "StartGame_RunApp": {
         "desc": "安卓原生控制器启动游戏；保留 base 的加载识别链，失败交给公共兜底，不执行 ADB Shell。",
         "action": "StartApp",
+        "package": "com.neowizgames.game.browndust2",
         "on_error": [
             "Global_Null_Exception",
             "Global_Null_Panic"

--- a/assets/resource/base/pipeline/StartGame.json
+++ b/assets/resource/base/pipeline/StartGame.json
@@ -6,28 +6,26 @@
         ]
     },
     "StartGame_Check_App_Alive": {
-        "desc": "步骤(shell探针)：查进程。如果活着> next ,>查不到经常on_error尝试抢救",
-        "action": "Shell",
-        "cmd": "dumpsys window | grep mCurrentFocus | grep com.neowizgames.game.browndust2",
+        "desc": "复用当前任务的启动准备结果。已在前台沿用当前场景；本轮拉起过则进入原有加载链。",
+        "action": "Custom",
+        "custom_action": "StartupCheckApp",
         "next": [
             "StartGame_TouchStart",
             "Global_ToHomePage_Enter",
             "Global_ToSandBox_Enter",
+            "StartGame_Logo",
+            "StartGame_LoadingPage",
             "Global_Null"
         ],
         "on_error": [
             "StartGame_RunApp"
-        ],
-        "focus": {
-            "Node.Action.Succeeded": "[color:green]程式已启动[/color]",
-            "Node.Action.Failed": "[color:red]程式未启动[/color]\n\n→程式启动模块"
-        }
+        ]
     },
     "StartGame_RunApp": {
-        "desc": "启动游戏。长白屏超时防御。框架的 StartApp 内部固定走 `monkey -p 包名 1`，部分模拟器 ROM 没有 monkey，失败后转 on_error 用 am start 兜底",
+        "desc": "启动准备适配入口；ADB 复用首节点检查，其他平台保留各自启动方式。登录和更新仍由下游节点处理。",
         "pre_wait_freezes": 500,
-        "action": "StartApp",
-        "package": "com.neowizgames.game.browndust2",
+        "action": "Custom",
+        "custom_action": "StartupRunApp",
         "post_delay": 8000,
         "timeout": 5000,
         "next": [
@@ -36,6 +34,9 @@
             "StartGame_GameIsMaint",
             "StartGame_Logo",
             "StartGame_LoadingPage",
+            "StartGame_TouchStart",
+            "Global_ToHomePage_Enter",
+            "Global_ToSandBox_Enter",
             "[JumpBack]Global_WaitingForLoading"
         ],
         "on_error": [
@@ -43,9 +44,9 @@
         ]
     },
     "StartGame_RunApp_Shell": {
-        "desc": "启动游戏兜底(不依赖 monkey)：实测雷电 LDPlayer14 的 ROM 缺 monkey，adb shell 直接返回 127，StartApp 必失败。改用 am start；Activity 名由 resolve-activity 现查，不写死，避免游戏改包结构后失效",
-        "action": "Shell",
-        "cmd": "am start -n $(cmd package resolve-activity --brief com.neowizgames.game.browndust2 | tail -1)",
+        "desc": "保留外部引用的兼容入口；启动策略统一由 agent 管理，不在这里再次执行 Shell。",
+        "action": "Custom",
+        "custom_action": "StartupRunApp",
         "post_delay": 8000,
         "timeout": 20000,
         "next": [
@@ -54,16 +55,15 @@
             "StartGame_GameIsMaint",
             "StartGame_Logo",
             "StartGame_LoadingPage",
+            "StartGame_TouchStart",
+            "Global_ToHomePage_Enter",
+            "Global_ToSandBox_Enter",
             "[JumpBack]Global_WaitingForLoading"
         ],
         "on_error": [
             "Global_Null_Exception",
             "Global_Null_Panic"
-        ],
-        "focus": {
-            "Node.Action.Succeeded": "[color:green]已用 am start 兜底启动(本模拟器无 monkey)[/color]",
-            "Node.Action.Failed": "[color:red][WRN] monkey 与 am start 均无法启动游戏，请手动开一次游戏再运行[/color]"
-        }
+        ]
     },
     "StartGame_Logo": {
         "recognition": "OCR",

--- a/assets/resource/base/pipeline/StartGame.json
+++ b/assets/resource/base/pipeline/StartGame.json
@@ -1,4 +1,12 @@
 {
+    "StartGame_PCWindowOptions": {
+        "desc": "PC 启动准备配置，仅供 pretask/sink 共享读取，不进入业务流程。",
+        "enabled": false,
+        "attach": {
+            "resolution": "720p",
+            "minimize": false
+        }
+    },
     "StartGame_Start": {
         "next": [
             "[JumpBack]Env_AccountSave_Switch",

--- a/docs/android.md
+++ b/docs/android.md
@@ -133,6 +133,8 @@ controller 声明，实际运行使用 AndroidNativeController；该版本未按
 筛选列表。安装脚本在生成 Android interface 时应用这些限制，仅保留可用的控制器和资源。
 当前项目产物中只保留 `Adb` / `ADB`。桌面源码 interface 和桌面安装产物继续包含各平台声明。
 安卓资源显示为“安卓原生机”，实际按 `base → android_native` 加载；任务及预设按控制器限制筛选。
+安卓打包只复制 `base`、`android_native` 两个资源包，另保留 `Announcement` 公告帮助和资源根目录文件；
+`pc`、`playcover` 等其他资源目录不进入产物，复用安装目录时也会清理这些残留。桌面仍复制全部资源。
 `android/maaowm.json` 是该覆盖包的 MaaOWM 配置，输出为 Pipeline V1。
 覆盖包只有两个启动节点：跳过不受支持的 Shell 探针，直接交给已实测成功的 StartApp；
 保留 base 的加载识别链，失败进入公共兜底，不再调用 Shell 启动兜底。

--- a/install.py
+++ b/install.py
@@ -48,6 +48,11 @@ def prepare_interface_for_target(interface, target_os):
     if not adb_name:
         raise ValueError("Android Adb controller requires a name")
     result["controller"] = [adb]
+    if "pretask" in result:
+        result["pretask"] = [
+            task for task in result["pretask"]
+            if not task.get("controller") or adb_name in task["controller"]
+        ]
 
     resources = []
     for resource in result.get("resource") or []:
@@ -246,6 +251,11 @@ def install_agent(target_os):
         if any(target_os.startswith(p) for p in ["win", "windows"]):
             interface["agent"]["child_exec"] = r"{PROJECT_DIR}/python/python.exe"
             interface["agent"]["child_args"] = ["-u", "-X", "utf8=1", r"{PROJECT_DIR}/agent/main.py"]
+            # MFAA v2.15.2 pretask cwd is resource/base; args have no placeholder expansion.
+            for pretask in interface.get("pretask", []):
+                if pretask.get("name") == "PC游戏启动准备":
+                    pretask["exec"] = "../../python/python.exe"
+                    pretask["args"] = ["-u", "-X", "utf8=1", "../../agent/pc_bootstrap.py"]
         
         # 2. macOS: 智能判断 (有嵌入用嵌入，没嵌入用系统)
         elif any(target_os.startswith(p) for p in ["macos", "darwin", "osx"]):

--- a/install.py
+++ b/install.py
@@ -245,6 +245,16 @@ def install_agent(target_os):
         if "agent" not in interface:
             interface["agent"] = {}
 
+        win32_names = {
+            controller["name"] for controller in interface.get("controller", [])
+            if controller.get("type") == "Win32" and controller.get("name")
+        }
+        if not any(target_os.startswith(p) for p in ["win", "windows"]) and "pretask" in interface:
+            interface["pretask"] = [
+                pretask for pretask in interface["pretask"]
+                if not pretask.get("controller") or not set(pretask["controller"]).issubset(win32_names)
+            ]
+
         # ==================== [核心路径配置] ====================
         
         # 1. Windows: 嵌入式 Python
@@ -253,9 +263,15 @@ def install_agent(target_os):
             interface["agent"]["child_args"] = ["-u", "-X", "utf8=1", r"{PROJECT_DIR}/agent/main.py"]
             # MFAA v2.15.2 pretask cwd is resource/base; args have no placeholder expansion.
             for pretask in interface.get("pretask", []):
-                if pretask.get("name") == "PC游戏启动准备":
+                args = pretask.get("args", [])
+                script_indices = [
+                    index for index, arg in enumerate(args)
+                    if Path(arg.replace("\\", "/")).name == "pc_bootstrap.py"
+                ]
+                if script_indices:
                     pretask["exec"] = "../../python/python.exe"
-                    pretask["args"] = ["-u", "-X", "utf8=1", "../../agent/pc_bootstrap.py"]
+                    for index in script_indices:
+                        args[index] = "../../agent/pc_bootstrap.py"
         
         # 2. macOS: 智能判断 (有嵌入用嵌入，没嵌入用系统)
         elif any(target_os.startswith(p) for p in ["macos", "darwin", "osx"]):
@@ -291,13 +307,22 @@ def install_agent(target_os):
 
     # 回读校验：确认写进去的确实是本平台的配置，而不是仓库里那份开发用路径。
     with open(interface_json_path, "r", encoding="utf-8") as f:
-        written = jsonc.load(f).get("agent", {}).get("child_exec", "")
+        written_interface = jsonc.load(f)
+    written = written_interface.get("agent", {}).get("child_exec", "")
     if written != interface["agent"]["child_exec"]:
         print(f"::error::child_exec 回读不符: 期望 {interface['agent']['child_exec']}，实得 {written}")
         sys.exit(1)
     if ".venv" in written:
         print(f"::error::child_exec 仍指向开发环境虚拟环境: {written}")
         sys.exit(1)
+    if written_interface.get("pretask") != interface.get("pretask"):
+        print("::error::pretask 回读不符: 写入后的内容与本次配置不一致")
+        sys.exit(1)
+    for pretask in written_interface.get("pretask", []):
+        for value in [pretask.get("exec", ""), *pretask.get("args", [])]:
+            if ".venv" in value.lower():
+                print(f"::error::pretask {pretask.get('name', '<unnamed>')!r} 仍指向开发环境虚拟环境: {value}")
+                sys.exit(1)
     print(f"✅ Agent 配置更新完成: {written}")
 
 if __name__ == "__main__":

--- a/install.py
+++ b/install.py
@@ -87,15 +87,37 @@ def prepare_interface_for_target(interface, target_os):
 # ... (保留原有注释代码) ...
 
 
+def copy_resources_for_target(source, destination, target_os):
+    """Copy resource packs, excluding other platforms from Android output."""
+    android = str(target_os).lower().startswith("android")
+    # Announcement is shared documentation, not a platform resource pack.
+    allowed = {"base", "android_native", "Announcement"}
+
+    def ignore(directory, names):
+        if not android or Path(directory) != source:
+            return []
+        return [name for name in names if (source / name).is_dir() and name not in allowed]
+
+    # A local Android build may reuse output from a previous desktop build.
+    if android and destination.exists():
+        for child in destination.iterdir():
+            if child.is_dir() and child.name not in allowed:
+                if child.is_symlink() or child.resolve().parent != destination.resolve():
+                    raise ValueError(f"Refusing to remove resource directory outside output: {child}")
+                shutil.rmtree(child)
+
+    shutil.copytree(
+        source,
+        destination,
+        dirs_exist_ok=True,
+        ignore=ignore,
+    )
+
+
 def install_resource():
     configure_ocr_model()
 
-    # 复制整个 resource 目录
-    shutil.copytree(
-        working_dir / "assets" / "resource",
-        install_path / "resource",
-        dirs_exist_ok=True,
-    )
+    copy_resources_for_target(working_dir / "assets" / "resource", install_path / "resource", target_os)
     
     # ================= [MFAA布局文件预配置写入开始] =================
     # 单文件适配: 显式复制 assets/mfa_layout.json 到 install/resource/

--- a/scripts/verify_android_interface_filter.py
+++ b/scripts/verify_android_interface_filter.py
@@ -40,6 +40,39 @@ class AndroidInterfaceFilterTest(unittest.TestCase):
         self.assertNotIn("pc-only", [task["name"] for task in filtered["task"]])
         self.assertNotIn("pc-only", [task["name"] for task in filtered["preset"][0]["task"]])
 
+    def test_pc_pretask_is_not_shipped_to_android(self):
+        filtered = INSTALL.prepare_interface_for_target(self.interface, "android")
+        self.assertEqual(filtered.get("pretask"), [])
+        self.assertTrue(self.interface["pretask"])
+        source = deepcopy(self.interface)
+        source["pretask"].extend([
+            {"name": "shared", "exec": "test"},
+            {"name": "adb-only", "exec": "test", "controller": ["Adb"]},
+        ])
+        filtered = INSTALL.prepare_interface_for_target(source, "android")
+        self.assertEqual([task["name"] for task in filtered["pretask"]], ["shared", "adb-only"])
+
+    def test_windows_install_rewrites_pretask_paths(self):
+        with tempfile.TemporaryDirectory() as work:
+            root = Path(work)
+            (root / "agent").mkdir()
+            (root / "agent" / "pc_bootstrap.py").write_text("# fixture", encoding="utf-8")
+            output = root / "install"
+            output.mkdir()
+            (output / "interface.json").write_text(json.dumps(self.interface), encoding="utf-8")
+            with patch.multiple(INSTALL, working_dir=root, install_path=output):
+                INSTALL.install_agent("win-x64")
+            installed = json.loads((output / "interface.json").read_text(encoding="utf-8"))
+            pretask = installed["pretask"][0]
+            self.assertEqual(pretask["exec"], "../../python/python.exe")
+            self.assertEqual(pretask["args"][-1], "../../agent/pc_bootstrap.py")
+            base = output / "resource" / "base"
+            self.assertEqual((base / pretask["args"][-1]).resolve(), (output / "agent" / "pc_bootstrap.py").resolve())
+            self.assertTrue((output / "agent" / "pc_bootstrap.py").is_file())
+        pretask = self.interface["pretask"][0]
+        self.assertEqual((ROOT / "assets/resource/base" / pretask["args"][-1]).resolve(), ROOT / "agent/pc_bootstrap.py")
+        self.assertEqual((ROOT / "assets/resource/base" / pretask["exec"]).resolve(), ROOT / ".venv/Scripts/python.exe")
+
     def test_installed_resources_follow_target_and_remove_stale_packs(self):
         with tempfile.TemporaryDirectory() as work:
             root = Path(work)

--- a/scripts/verify_android_interface_filter.py
+++ b/scripts/verify_android_interface_filter.py
@@ -1,9 +1,11 @@
 import importlib.util
 import json
 import sys
+import tempfile
 import unittest
 from copy import deepcopy
 from pathlib import Path
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -26,7 +28,9 @@ class AndroidInterfaceFilterTest(unittest.TestCase):
         self.assertEqual([item["name"] for item in filtered["resource"]], ["ADB"])
         self.assertEqual(filtered["resource"][0]["path"], ["./resource/base", "./resource/android_native"])
         self.assertNotIn("mirrorchyan_rid", filtered)
-        self.assertEqual(filtered["task"], self.interface["task"])
+        expected_tasks = [task for task in self.interface["task"]
+                          if not task.get("controller") or "Adb" in task["controller"]]
+        self.assertEqual(filtered["task"], expected_tasks)
 
     def test_task_and_preset_references_follow_controller_filter(self):
         source = deepcopy(self.interface)
@@ -35,6 +39,35 @@ class AndroidInterfaceFilterTest(unittest.TestCase):
         filtered = INSTALL.prepare_interface_for_target(source, "android")
         self.assertNotIn("pc-only", [task["name"] for task in filtered["task"]])
         self.assertNotIn("pc-only", [task["name"] for task in filtered["preset"][0]["task"]])
+
+    def test_installed_resources_follow_target_and_remove_stale_packs(self):
+        with tempfile.TemporaryDirectory() as work:
+            root = Path(work)
+            assets = root / "assets"
+            source = assets / "resource"
+            output = root / "install"
+            packs = {"base", "android_native", "Announcement", "pc", "playcover", "future_platform"}
+            for name in packs:
+                directory = source / name / "nested"
+                directory.mkdir(parents=True)
+                (directory / "content.txt").write_text(name, encoding="utf-8")
+            (assets / "interface.json").write_text(json.dumps(self.interface), encoding="utf-8")
+            (assets / "mfa_layout.json").write_text("{}", encoding="utf-8")
+            source_files = {path.relative_to(source): path.read_bytes() for path in source.rglob("*") if path.is_file()}
+            with patch.multiple(INSTALL, working_dir=root, install_path=output, version="v0.0.1"), \
+                    patch.object(INSTALL, "configure_ocr_model"):
+                # Reuse one output directory to exercise desktop -> Android cleanup.
+                for target in ("win-x64", "android-arm64", "android", "linux-x64"):
+                    with self.subTest(target=target), patch.object(INSTALL, "target_os", target):
+                        INSTALL.install_resource()
+                        expected = {"base", "android_native", "Announcement"} if target.startswith("android") else packs
+                        self.assertEqual({path.name for path in (output / "resource").iterdir() if path.is_dir()}, expected)
+                        for name in expected:
+                            self.assertEqual((output / "resource" / name / "nested" / "content.txt").read_text(encoding="utf-8"), name)
+                        self.assertEqual((output / "resource" / "mfa_layout.json").read_text(), "{}")
+                        installed = json.loads((output / "interface.json").read_text(encoding="utf-8"))
+                        self.assertEqual(installed["resource"], INSTALL.prepare_interface_for_target(self.interface, target)["resource"])
+            self.assertEqual({path.relative_to(source): path.read_bytes() for path in source.rglob("*") if path.is_file()}, source_files)
 
     def test_desktop_targets_are_unfiltered(self):
         filtered = INSTALL.prepare_interface_for_target(self.interface, "win-x64")

--- a/scripts/verify_android_interface_filter.py
+++ b/scripts/verify_android_interface_filter.py
@@ -1,4 +1,5 @@
 import importlib.util
+import io
 import json
 import sys
 import tempfile
@@ -72,6 +73,88 @@ class AndroidInterfaceFilterTest(unittest.TestCase):
         pretask = self.interface["pretask"][0]
         self.assertEqual((ROOT / "assets/resource/base" / pretask["args"][-1]).resolve(), ROOT / "agent/pc_bootstrap.py")
         self.assertEqual((ROOT / "assets/resource/base" / pretask["exec"]).resolve(), ROOT / ".venv/Scripts/python.exe")
+
+    def install_agent_fixture(self, interface, target, tamper=None):
+        with tempfile.TemporaryDirectory() as work:
+            root = Path(work)
+            (root / "agent").mkdir()
+            (root / "agent" / "pc_bootstrap.py").write_text("# fixture", encoding="utf-8")
+            output = root / "install"
+            output.mkdir()
+            interface_path = output / "interface.json"
+            interface_path.write_text(json.dumps(interface), encoding="utf-8")
+            original_dump = INSTALL.jsonc.dump
+
+            def dump(value, handle, **kwargs):
+                value = deepcopy(value)
+                if tamper is not None:
+                    tamper(value)
+                return original_dump(value, handle, **kwargs)
+
+            with patch.multiple(INSTALL, working_dir=root, install_path=output), \
+                    patch.object(INSTALL.jsonc, "dump", side_effect=dump):
+                INSTALL.install_agent(target)
+            return json.loads(interface_path.read_text(encoding="utf-8"))
+
+    def test_renamed_bootstrap_preserves_args_and_matches_both_slashes(self):
+        for script in ("../../../agent/pc_bootstrap.py", r"..\..\..\agent\pc_bootstrap.py"):
+            with self.subTest(script=script):
+                source = {
+                    "controller": [{"name": "renamed-pc", "type": "Win32"}],
+                    "pretask": [{"name": "renamed-bootstrap", "controller": ["renamed-pc"],
+                                 "exec": "../../../.venv/Scripts/python.exe",
+                                 "args": ["-B", "-u", script, "--custom-flag", "value"]}],
+                }
+                installed = self.install_agent_fixture(source, "win-x64")
+                self.assertEqual(installed["pretask"], [
+                    {**source["pretask"][0], "exec": "../../python/python.exe",
+                     "args": ["-B", "-u", "../../agent/pc_bootstrap.py", "--custom-flag", "value"]},
+                ])
+
+    def test_unrelated_pretask_venv_paths_fail_with_name(self):
+        for field, value in (("exec", "../../../.venv/Scripts/python.exe"),
+                             ("args", [r"..\.venv\other.py"])):
+            with self.subTest(field=field):
+                pretask = {"name": "unrelated-tool", "exec": "python3", "args": ["other.py"], field: value}
+                with patch("sys.stdout", new_callable=io.StringIO) as output, \
+                        self.assertRaises(SystemExit) as raised:
+                    self.install_agent_fixture({"pretask": [pretask]}, "win-x64")
+                self.assertEqual(raised.exception.code, 1)
+                self.assertIn("pretask 'unrelated-tool'", output.getvalue())
+                self.assertIn(".venv", output.getvalue())
+
+    def test_non_windows_drops_only_exclusively_win32_pretasks(self):
+        source = {
+            "controller": [{"name": "renamed-pc", "type": "Win32"},
+                           {"name": "second-pc", "type": "Win32"},
+                           {"name": "phone", "type": "Adb"},
+                           {"name": "mac", "type": "PlayCover"}],
+            "pretask": [
+                {"name": "pc-only", "controller": ["renamed-pc"], "exec": ".venv/python"},
+                {"name": "two-pcs", "controller": ["renamed-pc", "second-pc"], "exec": ".venv/python"},
+                {"name": "shared", "exec": "python3", "args": ["shared.py"]},
+                {"name": "empty", "controller": [], "exec": "python3"},
+                {"name": "mixed-adb", "controller": ["renamed-pc", "phone"], "exec": "python3"},
+                {"name": "mixed-other", "controller": ["renamed-pc", "mac"], "exec": "python3"},
+                {"name": "other-only", "controller": ["mac"], "exec": "python3"},
+            ],
+        }
+        for target in ("macos-arm64", "linux-x64"):
+            with self.subTest(target=target):
+                installed = self.install_agent_fixture(source, target)
+                self.assertEqual(installed["pretask"], source["pretask"][2:])
+
+    def test_pretask_readback_tampering_fails(self):
+        source = {"pretask": [{"name": "shared", "exec": "python3", "args": ["shared.py"]}]}
+
+        def tamper(value):
+            value["pretask"][0]["args"] = ["different.py"]
+
+        with patch("sys.stdout", new_callable=io.StringIO) as output, \
+                self.assertRaises(SystemExit) as raised:
+            self.install_agent_fixture(source, "linux-x64", tamper)
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("pretask 回读不符", output.getvalue())
 
     def test_installed_resources_follow_target_and_remove_stale_packs(self):
         with tempfile.TemporaryDirectory() as work:

--- a/scripts/verify_android_overlay.py
+++ b/scripts/verify_android_overlay.py
@@ -32,12 +32,14 @@ def main():
         assert resource.post_bundle(str(overlay_dir)).wait().succeeded
         check = resource.get_node_data(names[0])
         launch = resource.get_node_data(names[1])
-        assert before[names[0]]["action"]["type"] == "Shell"
+        assert before[names[0]]["action"]["type"] == "Custom"
+        assert before[names[0]]["action"]["param"]["custom_action"] == "StartupCheckApp"
         assert check["action"] == {"type": "DoNothing", "param": {}}
         assert check["focus"] is None
         assert [ref["name"] for ref in check["next"]] == [names[1]]
         assert not check["on_error"]
-        assert launch["action"] == before[names[1]]["action"]
+        assert before[names[1]]["action"]["param"]["custom_action"] == "StartupRunApp"
+        assert launch["action"] == {"type": "StartApp", "param": {"package": "com.neowizgames.game.browndust2"}}
         assert launch["next"] == before[names[1]]["next"]
         assert launch["timeout"] == before[names[1]]["timeout"]
         assert [ref["name"] for ref in launch["on_error"]] == ["Global_Null_Exception", "Global_Null_Panic"]

--- a/tools/test_pc_bootstrap_import.py
+++ b/tools/test_pc_bootstrap_import.py
@@ -1,0 +1,41 @@
+"""Verify the standalone pretask imports under isolated Python, without running it."""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class BootstrapImportTests(unittest.TestCase):
+    def test_isolated_interpreter_from_unrelated_working_directory(self):
+        script = ROOT / "agent/pc_bootstrap.py"
+        code = """
+import json
+import runpy
+import sys
+from pathlib import Path
+script = Path(sys.argv[1]).resolve()
+assert str(script.parent) not in sys.path
+runpy.run_path(str(script), run_name='bootstrap_import_test')
+import startup.common
+assert Path(startup.common.__file__).resolve() == script.parent / 'startup/common.py'
+assert 'startup.win32' not in sys.modules
+assert 'utils.host_watchdog' not in sys.modules
+assert 'maa' not in sys.modules
+print(json.dumps({'startup': str(Path(startup.common.__file__).resolve())}))
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            result = subprocess.run(
+                [sys.executable, "-I", "-B", "-X", "utf8=1", "-c", code, str(script)],
+                cwd=directory, capture_output=True, text=True, encoding="utf-8", timeout=15,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(Path(json.loads(result.stdout)["startup"]), script.parent.resolve() / "startup/common.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_pc_window_options.py
+++ b/tools/test_pc_window_options.py
@@ -1,0 +1,336 @@
+"""Offline contract tests; no production module outside the explicit allowlist loads."""
+import argparse
+import importlib.abc
+import importlib.util
+import json
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+DEFAULT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class BlockUnsafeImports(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split('.')[0] in ('maa', 'action', 'ctypes') or fullname in ('startup.sink', 'startup.win32'):
+            raise ImportError('Forbidden in offline tests: ' + fullname)
+
+
+def load_production(root):
+    sys.dont_write_bytecode = True
+    sys.meta_path.insert(0, BlockUnsafeImports())
+    package = types.ModuleType('startup')
+    package.__path__ = []
+    sys.modules['startup'] = package
+    adb = types.ModuleType('startup.adb')
+    adb.prepare = Mock(side_effect=AssertionError('Inject a fake ADB implementation'))
+    sys.modules['startup.adb'] = adb
+    loaded = []
+    for name in ('common', 'options', 'pc', 'guard'):
+        path = root / 'agent' / 'startup' / (name + '.py')
+        spec = importlib.util.spec_from_file_location('startup.' + name, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        loaded.append(module)
+    return loaded
+
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def sleep(self, seconds):
+        assert 0 < seconds <= 0.100001
+        self.now += seconds
+        assert self.now <= 301, 'Unbounded fake wait'
+
+
+class FakeAPI:
+    def __init__(self, size=(800, 600), minimized=False, fullscreen=False, pseudo=False):
+        self.size = size
+        self.iconic = minimized
+        self.full = fullscreen
+        self.pseudo = pseudo
+        self.calls = []
+        self.restore_ok = self.resize_ok = self.exit_ok = self.minimize_ok = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def is_game(self, hwnd):
+        return True
+
+    def client_size(self, hwnd):
+        self.calls.append(('read', self.size))
+        return self.size
+
+    def minimized(self, hwnd):
+        return self.iconic
+
+    def fullscreen(self, hwnd):
+        return self.full
+
+    def pseudo_minimized(self, hwnd):
+        return self.pseudo
+
+    def restore(self, hwnd):
+        self.calls.append(('restore',))
+        if self.restore_ok:
+            self.iconic = False
+        return self.restore_ok
+
+    def exit_fullscreen(self, hwnd):
+        self.calls.append(('exit',))
+        if self.exit_ok:
+            self.full = False
+
+    def resize_client(self, hwnd, target):
+        self.calls.append(('resize', target))
+        if self.resize_ok:
+            self.size = target
+
+    def minimize(self, hwnd):
+        self.calls.append(('minimize',))
+        if self.minimize_ok:
+            self.pseudo = True
+
+
+def context(kind='win32', attach=None):
+    ctx = types.SimpleNamespace()
+    ctx.tasker = types.SimpleNamespace(
+        controller=types.SimpleNamespace(info={'type': kind, 'hwnd': '0x123'}, uuid='fake'),
+        stopping=False, post_stop=Mock())
+    ctx.get_node_object = Mock(return_value=types.SimpleNamespace(attach={} if attach is None else attach))
+    ctx.get_task_job = Mock(return_value=types.SimpleNamespace(job_id=1))
+    return ctx
+
+
+class Contracts(unittest.TestCase):
+    def setUp(self):
+        self.clock = Clock()
+        self.logs = []
+        self.budget = common.Budget(self.logs.append, clock=self.clock, sleep=self.clock.sleep)
+
+    def prepare(self, api, resolution='720p', minimize=False):
+        return pc.prepare(api, self.budget, hwnd=0x123, options=options.PCOptions(resolution, minimize))
+
+    def budget_factory(self, report, cancelled):
+        return common.Budget(report, cancelled, clock=self.clock, sleep=self.clock.sleep)
+
+    def test_option_matrix_matches_pretask_and_attach(self):
+        for resolution, target in [('720p', (1280, 720)), ('1080p', (1920, 1080))]:
+            for label, value in [('Yes', True), ('No', False)]:
+                with self.subTest(resolution=resolution, minimize=label):
+                    payload = {options.RESOLUTION_OPTION: resolution, options.MINIMIZE_OPTION: label}
+                    left = options.PCOptions.from_pretask([json.dumps(payload)])
+                    ctx = context(attach={'resolution': resolution, 'minimize': value})
+                    self.assertEqual(left, options.PCOptions.from_context(ctx))
+                    self.assertEqual(left.target, target)
+                    self.assertIs(left.minimize, value)
+                    ctx.get_node_object.assert_called_once_with(options.NODE)
+
+    def test_defaults(self):
+        expected = options.PCOptions('720p', False)
+        for args in ([], ['{}']):
+            self.assertEqual(options.PCOptions.from_pretask(args), expected)
+        self.assertEqual(options.PCOptions.from_context(context()), expected)
+
+    def test_invalid_values_fail(self):
+        bad_pretask = ['broken', '[]', 'null', json.dumps({options.RESOLUTION_OPTION: '1440p'}),
+                       json.dumps({options.MINIMIZE_OPTION: True}), json.dumps({options.MINIMIZE_OPTION: 'yes'})]
+        for raw in bad_pretask:
+            with self.subTest(raw=raw), self.assertRaises(common.PreparationError):
+                options.PCOptions.from_pretask([raw])
+        with self.assertRaises(common.PreparationError):
+            options.PCOptions.from_pretask(['{}', '{}'])
+        for attach in ({'resolution': 'bad'}, {'minimize': 'Yes'}, {'minimize': 1}, []):
+            with self.subTest(attach=attach), self.assertRaises(common.PreparationError):
+                options.PCOptions.from_context(context(attach=attach))
+        ctx = context()
+        ctx.get_node_object.return_value = None
+        with self.assertRaises(common.PreparationError):
+            options.PCOptions.from_context(ctx)
+
+    def test_resize_readback_and_sink_log(self):
+        for resolution, target in options.RESOLUTIONS.items():
+            with self.subTest(resolution=resolution):
+                api = FakeAPI()
+                self.prepare(api, resolution)
+                self.assertEqual(api.size, target)
+                index = api.calls.index(('resize', target))
+                self.assertIn(('read', target), api.calls[index + 1:])
+                self.assertIn(f'[sink] 分辨率 800×600 → {target[0]}×{target[1]}（已调整', self.logs[-1])
+
+    def test_correct_size_explained(self):
+        api = FakeAPI(size=(1280, 720))
+        self.prepare(api)
+        self.assertFalse(any(c[0] == 'resize' for c in api.calls))
+        self.assertIn('[sink]', self.logs[-1])
+        self.assertIn('无需调整', self.logs[-1])
+
+    def test_failed_resize_is_not_reported_success(self):
+        api = FakeAPI()
+        api.resize_ok = False
+        with self.assertRaises(common.PreparationError):
+            self.prepare(api)
+        self.assertLessEqual(self.clock.now, 10)
+        self.assertNotIn('[PC窗口]', '\n'.join(self.logs))
+
+    def test_fullscreen_exit(self):
+        api = FakeAPI(fullscreen=True)
+        self.prepare(api)
+        self.assertEqual(api.calls.count(('exit',)), 1)
+        self.assertFalse(api.full)
+        self.assertIn('已退出全屏', self.logs[-1])
+
+    def test_fullscreen_failure_bounded(self):
+        api = FakeAPI(fullscreen=True)
+        api.exit_ok = False
+        with self.assertRaises(common.PreparationError):
+            self.prepare(api)
+        self.assertEqual(api.calls.count(('exit',)), 1)
+        self.assertLessEqual(self.clock.now, 10)
+
+    def test_minimized_restore(self):
+        api = FakeAPI(minimized=True)
+        self.prepare(api)
+        self.assertFalse(api.iconic)
+        self.assertEqual(api.size, (1280, 720))
+        self.assertIn('已还原窗口', self.logs[-1])
+
+    def test_restore_failure_bounded(self):
+        api = FakeAPI(minimized=True)
+        api.restore_ok = False
+        with self.assertRaises(common.PreparationError):
+            self.prepare(api)
+        self.assertLessEqual(self.clock.now, 10)
+
+    def test_minimize_after_resize(self):
+        api = FakeAPI()
+        self.prepare(api, minimize=True)
+        self.assertTrue(api.pseudo)
+        self.assertLess(api.calls.index(('read', (1280, 720))), api.calls.index(('minimize',)))
+
+    def test_pretask_defers_minimize_for_both_resolutions(self):
+        for resolution, target in options.RESOLUTIONS.items():
+            with self.subTest(resolution=resolution):
+                api = FakeAPI()
+                api.scan = Mock(return_value=([0x123], True, []))
+                api.minimize_ok = False
+                pc.prepare(api, self.budget, options=options.PCOptions(resolution, True))
+                self.assertEqual(api.size, target)
+                self.assertNotIn(('minimize',), api.calls)
+                self.assertFalse(api.iconic or api.pseudo)
+                self.assertIn('连接完成后', self.logs[-1])
+
+    def test_pretask_restores_existing_minimized_window_for_connection(self):
+        api = FakeAPI(size=(1280, 720), minimized=True)
+        api.scan = Mock(return_value=([0x123], True, []))
+        pc.prepare(api, self.budget, options=options.PCOptions(minimize=True))
+        self.assertFalse(api.iconic or api.pseudo)
+        self.assertIn(('restore',), api.calls)
+        self.assertNotIn(('minimize',), api.calls)
+
+    def test_sink_applies_minimize_after_pretask_and_connection(self):
+        api = FakeAPI()
+        api.scan = Mock(return_value=([0x123], True, []))
+        requested = options.PCOptions('1080p', True)
+        pc.prepare(api, self.budget, options=requested)
+        self.assertFalse(api.iconic or api.pseudo)
+        self.assertNotIn(('minimize',), api.calls)
+        pc.prepare(api, self.budget, hwnd=0x123, options=requested)
+        self.assertTrue(api.pseudo)
+        self.assertEqual(api.calls.count(('minimize',)), 1)
+        self.assertIn('[sink]', self.logs[-1])
+        self.assertIn('最小化', self.logs[-1])
+
+    def test_minimize_failure_bounded(self):
+        api = FakeAPI(size=(1280, 720))
+        api.minimize_ok = False
+        with self.assertRaisesRegex(common.PreparationError, '2 秒内未确认 PC 窗口最小化状态'):
+            self.prepare(api, minimize=True)
+        self.assertLessEqual(self.clock.now, 2.11)
+        self.assertEqual(api.calls.count(('minimize',)), 1)
+
+    def test_pseudo_minimized_correct_size_not_minimized_again(self):
+        api = FakeAPI(size=(1280, 720), pseudo=True)
+        self.prepare(api, minimize=True)
+        self.assertNotIn(('minimize',), api.calls)
+        self.assertFalse(any(c[0] == 'resize' for c in api.calls))
+        self.assertIn('无需调整', self.logs[-1])
+
+    def test_guard_framework_restore_when_minimize_disabled(self):
+        api = FakeAPI(size=(1280, 720))
+        fake_module = types.ModuleType('startup.win32')
+        fake_module.WindowsAPI = lambda: api
+        controller = context().tasker.controller
+        def inactive():
+            api.pseudo = False
+            return types.SimpleNamespace(done=True, succeeded=True)
+        controller.post_inactive = Mock(side_effect=inactive)
+        with patch.dict(sys.modules, {'startup.win32': fake_module}):
+            guard.StartupGuard._pc_prepare(controller, controller.info, self.budget, options.PCOptions(minimize=True))
+            self.assertTrue(api.pseudo)
+            guard.StartupGuard._pc_prepare(controller, controller.info, self.budget, options.PCOptions(minimize=False))
+        controller.post_inactive.assert_called_once_with()
+        self.assertFalse(api.pseudo)
+        self.assertIn('普通窗口', self.logs[-1])
+
+    def test_framework_restore_failure_and_timeout(self):
+        for done in (True, False):
+            with self.subTest(done=done):
+                self.setUp()
+                api = FakeAPI(size=(1280, 720), pseudo=True)
+                fake_module = types.ModuleType('startup.win32')
+                fake_module.WindowsAPI = lambda: api
+                controller = context().tasker.controller
+                controller.post_inactive = Mock(return_value=types.SimpleNamespace(done=done, succeeded=False))
+                with patch.dict(sys.modules, {'startup.win32': fake_module}), self.assertRaises(common.PreparationError):
+                    guard.StartupGuard._pc_prepare(controller, controller.info, self.budget, options.PCOptions())
+                self.assertLessEqual(self.clock.now, 5.11)
+
+    def test_guard_once_per_task_and_rereads_new_task(self):
+        prepare = Mock(return_value=common.Prepared())
+        g = guard.StartupGuard(self.logs.append, self.fail, pc_prepare=prepare, budget_factory=self.budget_factory)
+        ctx = context()
+        self.assertIsNotNone(g.ensure(ctx, 1))
+        ctx.get_node_object.return_value.attach = {'resolution': '1080p', 'minimize': True}
+        self.assertIsNotNone(g.ensure(ctx, 1))
+        self.assertEqual(prepare.call_count, 1)
+        self.assertEqual(ctx.get_node_object.call_count, 1)
+        self.assertIsNotNone(g.ensure(ctx, 2))
+        self.assertEqual(prepare.call_count, 2)
+        self.assertEqual(ctx.get_node_object.call_count, 2)
+        self.assertEqual(prepare.call_args_list[0].args[3], options.PCOptions())
+        self.assertEqual(prepare.call_args_list[1].args[3], options.PCOptions('1080p', True))
+
+    def test_non_pc_never_reads_pc_node(self):
+        for kind in ('adb', 'custom'):
+            with self.subTest(kind=kind):
+                ctx = context(kind)
+                ctx.get_node_object.side_effect = AssertionError('PC node accessed')
+                adb_prepare = Mock(return_value=common.Prepared())
+                pc_prepare = Mock(side_effect=AssertionError('PC prepare called'))
+                g = guard.StartupGuard(self.logs.append, self.fail, adb_prepare=adb_prepare, pc_prepare=pc_prepare,
+                                       budget_factory=self.budget_factory)
+                self.assertIsNotNone(g.ensure(ctx, 1))
+                ctx.get_node_object.assert_not_called()
+                pc_prepare.assert_not_called()
+                self.assertEqual(adb_prepare.call_count, int(kind == 'adb'))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--project-root', type=Path, default=Path(DEFAULT_ROOT))
+    args, remaining = parser.parse_known_args()
+    common, options, pc, guard = load_production(args.project_root.resolve())
+    unittest.main(argv=[sys.argv[0]] + remaining)

--- a/tools/test_pc_window_options.py
+++ b/tools/test_pc_window_options.py
@@ -70,8 +70,9 @@ class FakeAPI:
         return True
 
     def client_size(self, hwnd):
-        self.calls.append(('read', self.size))
-        return self.size
+        size = (0, 0) if self.iconic else self.size
+        self.calls.append(('read', size))
+        return size
 
     def minimized(self, hwnd):
         return self.iconic
@@ -220,6 +221,27 @@ class Contracts(unittest.TestCase):
         self.assertTrue(api.pseudo)
         self.assertLess(api.calls.index(('read', (1280, 720))), api.calls.index(('minimize',)))
 
+    def test_iconic_size_is_measured_after_restore(self):
+        api = FakeAPI(size=(1280, 720), minimized=True)
+        self.prepare(api, minimize=True)
+        self.assertIn(('read', (0, 0)), api.calls)
+        self.assertIn('1280×720 → 1280×720（无需调整', self.logs[-1])
+        self.assertNotIn('0×0 →', self.logs[-1])
+
+    def test_restore_can_finish_after_the_old_five_probe_limit(self):
+        api = FakeAPI(size=(1280, 720), minimized=True)
+        restore = api.restore
+        api.restore = lambda hwnd: restore(hwnd) if self.clock.now >= 2 else False
+        self.prepare(api)
+        self.assertGreaterEqual(self.clock.now, 2)
+        self.assertLess(self.clock.now, 10)
+
+    def test_pretask_orphan_transparency_gives_actionable_recovery(self):
+        api = FakeAPI(size=(1280, 720), pseudo=True)
+        api.scan = Mock(return_value=([0x123], True, []))
+        with self.assertRaisesRegex(common.PreparationError, '重启游戏'):
+            pc.prepare(api, self.budget)
+
     def test_pretask_defers_minimize_for_both_resolutions(self):
         for resolution, target in options.RESOLUTIONS.items():
             with self.subTest(resolution=resolution):
@@ -314,7 +336,7 @@ class Contracts(unittest.TestCase):
         self.assertEqual(prepare.call_args_list[1].args[3], options.PCOptions('1080p', True))
 
     def test_non_pc_never_reads_pc_node(self):
-        for kind in ('adb', 'custom'):
+        for kind in ('adb', 'custom', 'native_android'):
             with self.subTest(kind=kind):
                 ctx = context(kind)
                 ctx.get_node_object.side_effect = AssertionError('PC node accessed')

--- a/tools/test_startup_actions.py
+++ b/tools/test_startup_actions.py
@@ -1,0 +1,60 @@
+"""Offline checks for controller-specific StartGame action dispatch."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "agent"))
+from startup.common import Prepared
+
+
+class StartupActionTests(unittest.TestCase):
+    def setUp(self):
+        self.guard = types.SimpleNamespace(ensure=Mock(return_value=Prepared()))
+        modules = {}
+        for name in ("maa", "maa.agent", "maa.agent.agent_server", "maa.custom_action", "startup.sink", "utils"):
+            modules[name] = types.ModuleType(name)
+        modules["maa.agent.agent_server"].AgentServer = types.SimpleNamespace(custom_action=lambda name: lambda cls: cls)
+        modules["maa.custom_action"].CustomAction = object
+        modules["startup.sink"].guard = self.guard
+        modules["utils"].mfaalog = types.SimpleNamespace(info=Mock(), error=Mock())
+        with patch.dict(sys.modules, modules):
+            spec = importlib.util.spec_from_file_location("test_startup_adapter", ROOT / "agent/action/startup_prepare.py")
+            self.module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(self.module)
+
+    def context(self, kind):
+        controller = types.SimpleNamespace(info={"type": kind}, post_start_app=Mock())
+        return types.SimpleNamespace(tasker=types.SimpleNamespace(controller=controller, stopping=False, post_stop=Mock()))
+
+    def test_playcover_continues_manual_game_without_start_app(self):
+        context = self.context("playcover")
+        self.assertTrue(self.module.StartupRunApp().run(context, None))
+        context.tasker.controller.post_start_app.assert_not_called()
+        context.tasker.post_stop.assert_not_called()
+
+    def test_prepared_adb_and_pc_do_not_launch_again(self):
+        for kind in ("adb", "win32"):
+            context = self.context(kind)
+            self.assertTrue(self.module.StartupRunApp().run(context, None))
+            context.tasker.controller.post_start_app.assert_not_called()
+
+    def test_other_controller_keeps_its_start_app_path(self):
+        context = self.context("custom")
+        context.tasker.controller.post_start_app.return_value = types.SimpleNamespace(done=True, succeeded=True)
+        self.assertTrue(self.module.StartupRunApp().run(context, None))
+        context.tasker.controller.post_start_app.assert_called_once_with("com.neowizgames.game.browndust2")
+
+    def test_failed_guard_is_not_bypassed(self):
+        self.guard.ensure.return_value = None
+        context = self.context("playcover")
+        self.assertFalse(self.module.StartupRunApp().run(context, None))
+        context.tasker.controller.post_start_app.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/test_startup_prepare.py
+++ b/tools/test_startup_prepare.py
@@ -1,0 +1,402 @@
+"""Manual offline startup contract tests; Python 3.10+, no native imports."""
+
+import importlib.abc
+import re
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class NoNativeImports(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "action" or fullname.startswith("action.") or fullname in (
+            "startup.sink", "startup.win32", "maa"
+        ) or fullname.startswith("maa."):
+            raise AssertionError("Offline test attempted native import: " + fullname)
+        return None
+
+
+sys.meta_path.insert(0, NoNativeImports())
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "agent"))
+from startup import adb, pc, guard
+from startup.common import Budget, Cancelled, Prepared, PreparationError
+
+
+class Clock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def sleep(self, seconds):
+        if seconds < 0:
+            raise AssertionError("negative sleep")
+        self.now += seconds
+
+
+class Job:
+    def __init__(self, output=None, *, done=True, succeeded=True):
+        self.output = output
+        self.done = done
+        self.succeeded = succeeded
+
+    def get(self):
+        if not self.done:
+            raise AssertionError("read unfinished job")
+        return self.output
+
+    def wait(self):
+        raise AssertionError("blocking wait is forbidden")
+
+
+class Controller:
+    def __init__(self, respond=None, *, kind="adb", uuid="device-1"):
+        self.info = {"type": kind, "hwnd": 7}
+        self.uuid = uuid
+        self.respond = respond
+        self.commands = []
+
+    def post_shell(self, command, timeout):
+        self.commands.append((command, timeout))
+        answer = self.respond(command)
+        return answer if isinstance(answer, Job) else Job(answer)
+
+
+class NativeAPI:
+    """Only the injected PC surface; never loads the Windows adapter."""
+    def __init__(self, frames=None, *, valid=True, size=pc.TARGET):
+        self.frames = list(frames or [([7], True, [])])
+        self.valid = valid
+        self.size = size
+        self.scans = self.launches = self.resizes = 0
+        self.handles = []
+
+    def scan(self):
+        self.scans += 1
+        return self.frames.pop(0) if len(self.frames) > 1 else self.frames[0]
+
+    def launch(self):
+        self.launches += 1
+
+    def is_game(self, hwnd):
+        self.handles.append(hwnd)
+        return self.valid
+
+    def restore(self, hwnd):
+        self.handles.append(hwnd)
+
+    def fullscreen(self, hwnd):
+        return False
+
+    def client_size(self, hwnd):
+        return self.size
+
+    def resize_client(self, hwnd, target):
+        self.resizes += 1
+
+
+class Tasker:
+    def __init__(self, controller):
+        self.controller = controller
+        self.stopping = False
+        self.stops = 0
+
+    def post_stop(self):
+        self.stops += 1
+        return Job()
+
+
+class Context:
+    def __init__(self, controller, task_id=1):
+        self.tasker = Tasker(controller)
+        self.task_id = task_id
+
+    def get_task_job(self):
+        return SimpleNamespace(job_id=self.task_id)
+
+
+class ContractTest(unittest.TestCase):
+    def setUp(self):
+        self.clock = Clock()
+        self.messages = []
+
+    def budget(self, report=None, cancelled=lambda: False, **kwargs):
+        return Budget(self.messages.append if report is None else report,
+                      cancelled, clock=self.clock, sleep=self.clock.sleep, **kwargs)
+
+
+class BudgetTests(ContractTest):
+    def test_total_timeout_and_30_through_270_progress(self):
+        budget = self.budget()
+        with self.assertRaises(PreparationError):
+            budget.pause(1000)
+        self.assertEqual(self.clock.now, 300)
+        progress = [int(re.search(r"已等待 (\d+) 秒", text)[1])
+                    for text in self.messages if "已等待" in text]
+        self.assertEqual(progress, list(range(30, 300, 30)))
+        self.assertFalse(any("已等待 300" in text for text in self.messages))
+
+    def test_phases_share_one_deadline(self):
+        budget = self.budget()
+        budget.pause(200)
+        budget.phase = "second phase"
+        with self.assertRaises(PreparationError):
+            budget.pause(101)
+        self.assertEqual(self.clock.now, 300)
+
+    def test_cancel_during_pause(self):
+        budget = self.budget(cancelled=lambda: self.clock.now >= 1)
+        with self.assertRaises(Cancelled):
+            budget.pause(300)
+        self.assertLess(self.clock.now, 1.2)
+
+
+class ADBTests(ContractTest):
+    GAME = "mCurrentFocus=Window{1 " + adb.PACKAGE + "/.MainActivity}"
+    OTHER = "mCurrentFocus=Window{1 com.android.launcher/.Home}"
+
+    def test_already_foreground_does_not_launch(self):
+        controller = Controller(lambda cmd: self.GAME)
+        self.assertFalse(adb.prepare(controller, self.budget()).changed)
+        self.assertEqual([c for c, _ in controller.commands], ["dumpsys window windows"])
+
+    def test_manual_foreground_after_unknown_uses_loading_branch(self):
+        outputs = iter(["mCurrentFocus=null", "unknown", self.GAME])
+        controller = Controller(lambda cmd: next(outputs))
+        self.assertTrue(adb.prepare(controller, self.budget()).changed)
+        self.assertTrue(all(cmd.startswith("dumpsys") for cmd, _ in controller.commands))
+
+    def test_unknown_never_launches(self):
+        controller = Controller(lambda cmd: "Permission Denial: inaccessible")
+        with self.assertRaises(PreparationError):
+            adb.prepare(controller, self.budget())
+        self.assertTrue(all(c.startswith("dumpsys ") for c, _ in controller.commands))
+        self.assertEqual(self.clock.now, 300)
+
+    def test_am_then_monkey_each_once_even_if_game_never_arrives(self):
+        def respond(command):
+            if command.startswith("dumpsys"):
+                return self.OTHER
+            if command.startswith("cmd package"):
+                return adb.PACKAGE + "/.MainActivity"
+            return "Error: launch failed"
+        controller = Controller(respond)
+        with self.assertRaises(PreparationError):
+            adb.prepare(controller, self.budget())
+        launches = [c.split()[0] for c, _ in controller.commands
+                    if c.startswith(("am ", "monkey "))]
+        self.assertEqual(launches, ["am", "monkey"])
+        self.assertEqual(sum(c.startswith("cmd package") for c, _ in controller.commands), 1)
+
+    def test_resolve_failure_still_allows_monkey(self):
+        launched = []
+        def respond(command):
+            if command.startswith("dumpsys"):
+                return self.GAME if launched else self.OTHER
+            if command.startswith("monkey "):
+                launched.append(command)
+                return "Events injected: 1"
+            return "Error: unable to resolve Intent"
+        controller = Controller(respond)
+        self.assertTrue(adb.prepare(controller, self.budget()).changed)
+        self.assertEqual(len(launched), 1)
+        self.assertFalse(any(c.startswith("am ") for c, _ in controller.commands))
+
+    def test_error_and_conflicting_foreground_are_unknown(self):
+        for output in (None, "", "Error: " + self.OTHER,
+                       "SecurityException " + self.GAME,
+                       self.GAME + "\n" + self.OTHER,
+                       "mCurrentFocus=null"):
+            with self.subTest(output=output):
+                self.assertEqual(adb.parse_foreground(output, ("mCurrentFocus=",)),
+                                 adb.Foreground.UNKNOWN)
+
+    def test_failed_job_output_cannot_become_other_foreground(self):
+        controller = Controller(lambda cmd: Job(self.OTHER, succeeded=False))
+        self.assertEqual(adb.foreground(controller, self.budget()), adb.Foreground.UNKNOWN)
+
+    def test_activity_fallback_can_confirm_foreground(self):
+        controller = Controller(lambda cmd: "Error: no window permission" if "window" in cmd
+                                else "topResumedActivity=ActivityRecord{ " + adb.PACKAGE + "/.Main}")
+        self.assertEqual(adb.foreground(controller, self.budget()), adb.Foreground.GAME)
+
+    def test_unfinished_job_cannot_queue_followup(self):
+        controller = Controller(lambda cmd: Job(done=False))
+        with self.assertRaises(PreparationError):
+            adb.prepare(controller, self.budget())
+        self.assertEqual(len(controller.commands), 1)
+        self.assertLessEqual(self.clock.now, 5.1)
+
+    def test_cancellation_with_unfinished_job_does_not_queue(self):
+        controller = Controller(lambda cmd: Job(done=False))
+        with self.assertRaises(Cancelled):
+            adb.prepare(controller, self.budget(cancelled=lambda: self.clock.now >= 0.5))
+        self.assertEqual(len(controller.commands), 1)
+        self.assertLess(self.clock.now, 0.7)
+
+
+class PCTests(ContractTest):
+    def test_old_launcher_error_keeps_waiting_for_main_window(self):
+        api = NativeAPI([([], True, ["ERROR"]), ([], True, ["ERROR"]), ([7], True, [])])
+        pc.prepare(api, self.budget())
+        self.assertEqual(api.launches, 0)
+        self.assertEqual(api.scans, 3)
+        self.assertTrue(any("ERROR" in text for text in self.messages))
+
+    def test_existing_verified_window_is_accepted_immediately(self):
+        api = NativeAPI()
+        pc.prepare(api, self.budget())
+        self.assertEqual((api.launches, api.scans, self.clock.now), (0, 1, 0))
+
+    def test_fullscreen_toggle_is_not_repeated_when_unresponsive(self):
+        api = NativeAPI()
+        api.toggles = 0
+        api.fullscreen = lambda hwnd: True
+        def toggle(hwnd):
+            api.toggles += 1
+        api.exit_fullscreen = toggle
+        with self.assertRaises(PreparationError):
+            pc.prepare(api, self.budget(), hwnd=7)
+        self.assertEqual(api.toggles, 1)
+        self.assertEqual(api.resizes, 0)
+        self.assertLessEqual(self.clock.now, 10)
+
+    def test_minimized_window_is_not_accepted_until_restored(self):
+        api = NativeAPI()
+        states = iter([False, False, True])
+        api.restore = lambda hwnd: next(states)
+        pc.prepare(api, self.budget(), hwnd=7)
+        self.assertAlmostEqual(self.clock.now, 0.4)
+
+    def test_fullscreen_exit_then_resize_is_verified(self):
+        api = NativeAPI(size=(1920, 1080))
+        api.is_fullscreen = True
+        api.fullscreen = lambda hwnd: api.is_fullscreen
+        api.exit_fullscreen = lambda hwnd: setattr(api, "is_fullscreen", False)
+        api.resize_client = lambda hwnd, target: setattr(api, "size", target)
+        pc.prepare(api, self.budget(), hwnd=7)
+        self.assertFalse(api.is_fullscreen)
+        self.assertEqual(api.size, (1280, 720))
+
+    def test_never_launch_twice_while_waiting(self):
+        api = NativeAPI([([], False, [])])
+        with self.assertRaises(PreparationError):
+            pc.prepare(api, self.budget())
+        self.assertEqual(api.launches, 1)
+        self.assertEqual(self.clock.now, 300)
+
+    def test_main_window_arrives_immediately_after_launch(self):
+        api = NativeAPI([([], False, []), ([7], True, [])])
+        self.assertTrue(pc.prepare(api, self.budget()).changed)
+        self.assertEqual((api.launches, api.scans), (1, 2))
+        self.assertLessEqual(self.clock.now, 2)
+
+    def test_multiple_games_rejected_before_mutation(self):
+        api = NativeAPI([([7, 8], True, [])])
+        with self.assertRaises(PreparationError):
+            pc.prepare(api, self.budget())
+        self.assertEqual((api.launches, api.resizes, api.handles), (0, 0, []))
+
+    def test_invalid_bound_handle_never_rebinds(self):
+        api = NativeAPI([([8], True, [])], valid=False)
+        with self.assertRaises(PreparationError):
+            pc.prepare(api, self.budget(), hwnd=7)
+        self.assertEqual((api.scans, api.launches), (0, 0))
+        self.assertEqual(set(api.handles), {7})
+
+    def test_size_readback_failure_is_bounded(self):
+        for size in (None, (0, 0), (1920, 1080)):
+            with self.subTest(size=size):
+                self.clock = Clock()
+                api = NativeAPI(size=size)
+                with self.assertRaises(PreparationError):
+                    pc.prepare(api, self.budget(), hwnd=7)
+                self.assertLessEqual(self.clock.now, 10)
+                self.assertLessEqual(api.resizes, 5)
+                self.assertEqual(api.scans, 0)
+
+
+class GuardTests(ContractTest):
+    def make_guard(self, prepare=None):
+        self.calls = []
+        self.errors = []
+        def prepared(*args):
+            self.calls.append(args)
+            return Prepared()
+        return guard.StartupGuard(self.messages.append, self.errors.append,
+                                  budget_factory=self.budget,
+                                  adb_prepare=prepare or prepared, pc_prepare=prepare or prepared)
+
+    def test_actual_type_bypasses_even_if_label_says_pc(self):
+        gate = self.make_guard()
+        for kind in ("playcover", "custom", "", None):
+            controller = Controller(kind=kind, uuid=None)
+            controller.info["name"] = "PC客户端"
+            context = Context(controller)
+            self.assertEqual(gate.ensure(context), Prepared())
+            self.assertEqual(context.tasker.stops, 0)
+        self.assertEqual(self.calls, [])
+        self.assertEqual(self.messages, [])
+
+    def test_actual_type_selects_pc_despite_adb_label(self):
+        gate = self.make_guard()
+        controller = Controller(kind="win32")
+        controller.info["name"] = "Adb"
+        gate.ensure(Context(controller))
+        self.assertEqual(len(self.calls[0]), 3)
+
+    def test_uuid_and_task_id_deduplicate_across_controller_objects(self):
+        gate = self.make_guard()
+        first = gate.ensure(Context(Controller(uuid="same"), 10))
+        second = gate.ensure(Context(Controller(uuid="same"), 10))
+        self.assertIs(first, second)
+        self.assertEqual(len(self.calls), 1)
+        gate.ensure(Context(Controller(uuid="other"), 10))
+        self.assertEqual(len(self.calls), 2)
+
+    def test_new_task_rechecks_and_explicit_task_id_is_used(self):
+        gate = self.make_guard()
+        context = Context(Controller(), 1)
+        gate.ensure(context)
+        context.task_id = 2
+        gate.ensure(context)
+        gate.ensure(context, task_id=3)
+        gate.ensure(context, task_id=3)
+        self.assertEqual(len(self.calls), 3)
+
+    def test_failure_new_task_stops_fast_without_wait(self):
+        attempts = []
+        def fail(controller, budget):
+            attempts.append(controller)
+            budget.pause(1)
+            raise PreparationError("contract failure")
+        gate = self.make_guard(fail)
+        context = Context(Controller())
+        self.assertIsNone(gate.ensure(context))
+        elapsed = self.clock.now
+        context.task_id = 2
+        self.assertIsNone(gate.ensure(context))
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(self.clock.now, elapsed)
+        self.assertEqual(context.tasker.stops, 2)
+        self.assertTrue(all("contract failure" in error for error in self.errors))
+
+    def test_cancel_stops_without_poisoning_next_task(self):
+        def prepare(controller, budget):
+            budget.check()
+            return Prepared()
+        gate = self.make_guard(prepare)
+        context = Context(Controller())
+        context.tasker.stopping = True
+        self.assertIsNone(gate.ensure(context))
+        self.assertEqual(context.tasker.stops, 1)
+        context.tasker.stopping = False
+        context.task_id = 2
+        self.assertEqual(gate.ensure(context), Prepared())
+        self.assertEqual(self.errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/test_startup_prepare.py
+++ b/tools/test_startup_prepare.py
@@ -90,6 +90,12 @@ class NativeAPI:
     def fullscreen(self, hwnd):
         return False
 
+    def minimized(self, hwnd):
+        return False
+
+    def pseudo_minimized(self, hwnd):
+        return False
+
     def client_size(self, hwnd):
         return self.size
 
@@ -115,6 +121,11 @@ class Context:
 
     def get_task_job(self):
         return SimpleNamespace(job_id=self.task_id)
+
+    def get_node_object(self, name):
+        if name != "StartGame_PCWindowOptions":
+            raise AssertionError("Unexpected node: " + name)
+        return SimpleNamespace(attach={})
 
 
 class ContractTest(unittest.TestCase):
@@ -345,7 +356,7 @@ class GuardTests(ContractTest):
         controller = Controller(kind="win32")
         controller.info["name"] = "Adb"
         gate.ensure(Context(controller))
-        self.assertEqual(len(self.calls[0]), 3)
+        self.assertEqual(len(self.calls[0]), 4)
 
     def test_uuid_and_task_id_deduplicate_across_controller_objects(self):
         gate = self.make_guard()

--- a/tools/test_startup_prepare.py
+++ b/tools/test_startup_prepare.py
@@ -139,6 +139,17 @@ class ContractTest(unittest.TestCase):
 
 
 class BudgetTests(ContractTest):
+    def test_success_report_does_not_revoke_readiness_at_deadline(self):
+        budget = self.budget()
+        self.clock.now = 300.1
+        budget.success()
+        self.assertIn("完成", self.messages[-1])
+
+    def test_success_still_honors_cancellation(self):
+        budget = self.budget(cancelled=lambda: True)
+        with self.assertRaises(Cancelled):
+            budget.success()
+
     def test_total_timeout_and_30_through_270_progress(self):
         budget = self.budget()
         with self.assertRaises(PreparationError):
@@ -165,6 +176,12 @@ class BudgetTests(ContractTest):
 
 
 class ADBTests(ContractTest):
+    def test_unrelated_diagnostic_text_does_not_mask_foreground(self):
+        output = "last exception: background error: not found\n" + f"mCurrentFocus=Window{{123 u0 {adb.PACKAGE}/.Main}}"
+        self.assertEqual(adb.parse_foreground(output, ("mCurrentFocus=",)), adb.Foreground.GAME)
+        self.assertEqual(adb.parse_foreground("mCurrentFocus=Window{123 u0 com.exception.launcher/.Main}", ("mCurrentFocus=",)), adb.Foreground.OTHER)
+        self.assertEqual(adb.parse_foreground("Permission Denial: blocked\n" + output, ("mCurrentFocus=",)), adb.Foreground.UNKNOWN)
+
     GAME = "mCurrentFocus=Window{1 " + adb.PACKAGE + "/.MainActivity}"
     OTHER = "mCurrentFocus=Window{1 com.android.launcher/.Home}"
 
@@ -325,11 +342,25 @@ class PCTests(ContractTest):
                 with self.assertRaises(PreparationError):
                     pc.prepare(api, self.budget(), hwnd=7)
                 self.assertLessEqual(self.clock.now, 10)
-                self.assertLessEqual(api.resizes, 5)
+                self.assertLessEqual(api.resizes, 20)
                 self.assertEqual(api.scans, 0)
 
 
 class GuardTests(ContractTest):
+    def test_identity_failure_does_not_poison_reconnection_or_other_types(self):
+        gate = self.make_guard()
+        class Unavailable:
+            @property
+            def info(self):
+                raise RuntimeError()
+        broken = Context(Unavailable())
+        self.assertIsNone(gate.ensure(broken))
+        self.assertEqual(broken.tasker.stops, 1)
+        self.assertIn("RuntimeError", self.errors[-1])
+        self.assertEqual(gate.ensure(Context(Controller(kind="custom"), 2)), Prepared())
+        self.assertEqual(gate.ensure(Context(Controller(), 3)), Prepared())
+        self.assertEqual(len(self.calls), 1)
+
     def make_guard(self, prepare=None):
         self.calls = []
         self.errors = []
@@ -342,7 +373,7 @@ class GuardTests(ContractTest):
 
     def test_actual_type_bypasses_even_if_label_says_pc(self):
         gate = self.make_guard()
-        for kind in ("playcover", "custom", "", None):
+        for kind in ("playcover", "custom", "native_android", "", None):
             controller = Controller(kind=kind, uuid=None)
             controller.info["name"] = "PC客户端"
             context = Context(controller)

--- a/tools/verify_startup_native.py
+++ b/tools/verify_startup_native.py
@@ -1,0 +1,199 @@
+"""Manual native Maa/Agent transport test using a synthetic controller only.
+
+Usage: python tools/verify_startup_native.py --maa-dir <isolated site-packages>
+       --work-dir <scratch output>
+No ADB connection, real screenshot, real input or game process is used.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def agent(identifier, mode):
+    from maa.agent.agent_server import AgentServer
+    from maa.custom_action import CustomAction
+    from maa.controller import Controller
+    from startup.common import Budget
+
+    # Match main.py: existing custom registrations initialize v5.12.2 bindings
+    # before the context-sink decorator runs.
+    @AgentServer.custom_action("test_initialize_bindings")
+    class Initialize(CustomAction):
+        def run(self, context, argv):
+            return True
+
+    from startup.sink import guard
+
+    original_info = Controller.info.fget
+
+    def synthetic_adb_info(self):
+        info = original_info(self)
+        # The real transport is used; only the synthetic controller's routing
+        # identity is changed so the production ADB guard can be exercised.
+        if self.uuid == "startup-test":
+            return dict(info, type="adb")
+        return info
+
+    Controller.info = property(synthetic_adb_info)
+    if mode == "failure":
+        guard.budget_factory = lambda report, cancelled: Budget(report, cancelled, timeout=0.5)
+    assert AgentServer.start_up(identifier)
+    AgentServer.join()
+    AgentServer.shut_down()
+
+
+def run(mode, work, maa_dir):
+    import numpy as np
+    from maa.agent_client import AgentClient
+    from maa.controller import CustomController
+    from maa.custom_recognition import CustomRecognition
+    from maa.resource import Resource
+    from maa.tasker import Tasker
+
+    class Synthetic(CustomController):
+        def __init__(self):
+            self.commands = []
+            self.frames = self.clicks = 0
+            self.foreground = False
+            super().__init__()
+
+        def connect(self): return True
+        def request_uuid(self): return "startup-test"
+        def get_features(self): return 0
+        def start_app(self, intent): raise AssertionError("Unexpected StartApp")
+        def stop_app(self, intent): raise AssertionError("Unexpected StopApp")
+        def swipe(self, *args): return False
+        def touch_down(self, *args): return False
+        def touch_move(self, *args): return False
+        def touch_up(self, *args): return False
+        def click_key(self, *args): return False
+        def input_text(self, *args): return False
+        def key_down(self, *args): return False
+        def key_up(self, *args): return False
+
+        def screencap(self):
+            assert self.foreground, "Business screenshot ran before preparation"
+            self.frames += 1
+            return np.zeros((720, 1280, 3), dtype=np.uint8)
+
+        def click(self, x, y):
+            assert self.foreground, "Business input ran before preparation"
+            self.clicks += 1
+            return True
+
+        def shell(self, cmd, timeout):
+            assert 0 < timeout <= 5000
+            self.commands.append(cmd)
+            if mode == "failure":
+                return "Permission Denial: test fixture"
+            if cmd.startswith("dumpsys"):
+                package = "com.neowizgames.game.browndust2" if self.foreground else "com.android.launcher"
+                return f"mCurrentFocus=Window{{123 u0 {package}/.Main}}"
+            if cmd.startswith("cmd package"):
+                return "com.neowizgames.game.browndust2/.Main"
+            if cmd.startswith("am start"):
+                self.foreground = True
+                return "Starting: Intent"
+            raise AssertionError(cmd)
+
+    folder = work / mode
+    (folder / "resource/pipeline").mkdir(parents=True, exist_ok=True)
+    nodes = {
+        "test_entry": {"action": "Click", "target": [1, 1], "pre_delay": 0, "post_delay": 0, "next": ["test_next"]},
+        "test_next": {"action": "Click", "target": [1, 1], "pre_delay": 0, "post_delay": 0},
+    }
+    if mode == "node_timeout":
+        nodes["test_entry"] = {"recognition": "Custom", "custom_recognition": "test_never",
+                               "timeout": 100, "rate_limit": 0, "on_error": ["test_next"]}
+    (folder / "resource/pipeline/test.json").write_text(json.dumps(nodes), encoding="utf-8")
+    Tasker.set_log_dir(folder / "log")
+    resource, controller, tasker = Resource(), Synthetic(), Tasker()
+    class Never(CustomRecognition):
+        count = 0
+
+        def analyze(self, context, argv):
+            self.count += 1
+            return None
+
+    never = Never()
+    assert resource.register_custom_recognition("test_never", never)
+    assert resource.post_bundle(folder / "resource").wait().succeeded
+    assert controller.post_connection().wait().succeeded
+    assert tasker.bind(resource, controller)
+    client = AgentClient()
+    assert client.bind(resource)
+    assert client.register_sink(resource, controller, tasker)
+    assert client.set_timeout(10000)
+    command = [sys.executable, "-B", "-X", "utf8=1", str(Path(__file__).resolve()),
+               "--maa-dir", str(maa_dir), "--work-dir", str(work), "--agent", client.identifier, "--mode", mode]
+    with (folder / "agent.log").open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT,
+                                   creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+        try:
+            assert client.connect()
+            statuses = []
+            for index in range(1 if mode == "node_timeout" else 2):
+                started = time.monotonic()
+                job = tasker.post_task("test_entry")
+                while not job.done and time.monotonic() - started < 15:
+                    time.sleep(0.02)
+                assert job.done, "Native task did not complete"
+                statuses.append(dict(succeeded=job.succeeded, failed=job.failed))
+                if mode == "failure":
+                    assert controller.frames == controller.clicks == 0
+                    if index == 0:
+                        first_commands = len(controller.commands)
+                    else:
+                        assert len(controller.commands) == first_commands, "Failure was not latched"
+                        assert time.monotonic() - started < 2
+                elif mode == "node_timeout":
+                    assert never.count == 1, "Preparation time no longer charges the original recognition timeout"
+                    assert controller.clicks == 1
+                    assert time.monotonic() - started >= 2
+                else:
+                    assert controller.clicks == (index + 1) * 2
+                    assert len(controller.commands) == 4 + index, controller.commands
+            report = dict(mode=mode, frames=controller.frames, clicks=controller.clicks,
+                          commands=controller.commands, statuses=statuses, misses=never.count)
+            (folder / "result.json").write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+            print(json.dumps(report, ensure_ascii=False))
+        finally:
+            client.disconnect()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()  # Only this test's own synthetic agent process.
+                process.wait(timeout=5)
+    assert process.returncode == 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--maa-dir", type=Path, required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument("--agent")
+    parser.add_argument("--mode", choices=("success", "failure", "node_timeout"))
+    args = parser.parse_args()
+    sys.path[:0] = [str(args.maa_dir), str(ROOT / "agent")]
+    if args.agent:
+        import maa.agent  # Select server mode before the first Library call.
+    from maa.library import Library
+
+    print("MaaFramework:", Library.version(), flush=True)
+    assert Library.version() == "v5.12.2", "Use the project's pinned desktop runtime"
+    if args.agent:
+        agent(args.agent, args.mode)
+    else:
+        for mode in ("success", "failure", "node_timeout"):
+            run(mode, args.work_dir, args.maa_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/verify_startup_native.py
+++ b/tools/verify_startup_native.py
@@ -22,14 +22,21 @@ def agent(identifier, mode):
     from maa.controller import Controller
     from startup.common import Budget
 
-    # Match main.py: existing custom registrations initialize v5.12.2 bindings
-    # before the context-sink decorator runs.
-    @AgentServer.custom_action("test_initialize_bindings")
-    class Initialize(CustomAction):
-        def run(self, context, argv):
-            return True
-
+    # Import the sink before any custom registrations to verify it initializes
+    # its own binding instead of relying on unrelated action import order.
     from startup.sink import guard
+
+    @AgentServer.custom_action("test_nested")
+    class Nested(CustomAction):
+        def run(self, context, argv):
+            root_id = context.get_task_job().job_id
+            assert context.get_node_object("StartGame_PCWindowOptions").attach == {"resolution": "1080p", "minimize": True}
+            for _ in range(2):
+                job = context.run_task("test_child")
+                assert job and job.status.succeeded
+                assert job.task_id != root_id
+                assert context.get_task_job().job_id == root_id
+            return True
 
     original_info = Controller.info.fget
 
@@ -106,12 +113,16 @@ def run(mode, work, maa_dir):
     folder = work / mode
     (folder / "resource/pipeline").mkdir(parents=True, exist_ok=True)
     nodes = {
+        "StartGame_PCWindowOptions": {"enabled": False, "attach": {"resolution": "720p", "minimize": False}},
         "test_entry": {"action": "Click", "target": [1, 1], "pre_delay": 0, "post_delay": 0, "next": ["test_next"]},
         "test_next": {"action": "Click", "target": [1, 1], "pre_delay": 0, "post_delay": 0},
     }
     if mode == "node_timeout":
         nodes["test_entry"] = {"recognition": "Custom", "custom_recognition": "test_never",
                                "timeout": 100, "rate_limit": 0, "on_error": ["test_next"]}
+    elif mode == "nested":
+        nodes["test_entry"].update(action="Custom", custom_action="test_nested")
+        nodes["test_child"] = {"action": "Click", "target": [1, 1], "pre_delay": 0, "post_delay": 0}
     (folder / "resource/pipeline/test.json").write_text(json.dumps(nodes), encoding="utf-8")
     Tasker.set_log_dir(folder / "log")
     resource, controller, tasker = Resource(), Synthetic(), Tasker()
@@ -125,6 +136,15 @@ def run(mode, work, maa_dir):
     never = Never()
     assert resource.register_custom_recognition("test_never", never)
     assert resource.post_bundle(folder / "resource").wait().succeeded
+    # Verify native attach parsing for all four option combinations.
+    interface = json.loads((ROOT / "assets/interface.json").read_text(encoding="utf-8"), strict=False)
+    for resolution in interface["option"]["PC窗口分辨率"]["cases"]:
+        for minimize in interface["option"]["PC启动最小化"]["cases"]:
+            assert resource.override_pipeline(resolution["pipeline_override"])
+            assert resource.override_pipeline(minimize["pipeline_override"])
+            assert resource.get_node_object("StartGame_PCWindowOptions").attach == {
+                "resolution": resolution["name"], "minimize": minimize["name"] == "Yes"}
+    assert resource.override_pipeline({"StartGame_PCWindowOptions": {"attach": {"resolution": "720p", "minimize": False}}})
     assert controller.post_connection().wait().succeeded
     assert tasker.bind(resource, controller)
     client = AgentClient()
@@ -141,7 +161,12 @@ def run(mode, work, maa_dir):
             statuses = []
             for index in range(1 if mode == "node_timeout" else 2):
                 started = time.monotonic()
-                job = tasker.post_task("test_entry")
+                # The UI submits an array to Tasker (Resource accepts objects).
+                overrides = [
+                    {"StartGame_PCWindowOptions": {"attach": {"resolution": "1080p"}}},
+                    {"StartGame_PCWindowOptions": {"attach": {"minimize": True}}},
+                ]
+                job = tasker.post_task("test_entry", overrides)
                 while not job.done and time.monotonic() - started < 15:
                     time.sleep(0.02)
                 assert job.done, "Native task did not complete"
@@ -158,7 +183,7 @@ def run(mode, work, maa_dir):
                     assert controller.clicks == 1
                     assert time.monotonic() - started >= 2
                 else:
-                    assert controller.clicks == (index + 1) * 2
+                    assert controller.clicks == (index + 1) * (3 if mode == "nested" else 2)
                     assert len(controller.commands) == 4 + index, controller.commands
             report = dict(mode=mode, frames=controller.frames, clicks=controller.clicks,
                           commands=controller.commands, statuses=statuses, misses=never.count)
@@ -179,7 +204,7 @@ def main():
     parser.add_argument("--maa-dir", type=Path, required=True)
     parser.add_argument("--work-dir", type=Path, required=True)
     parser.add_argument("--agent")
-    parser.add_argument("--mode", choices=("success", "failure", "node_timeout"))
+    parser.add_argument("--mode", choices=("success", "failure", "node_timeout", "nested"))
     args = parser.parse_args()
     sys.path[:0] = [str(args.maa_dir), str(ROOT / "agent")]
     if args.agent:
@@ -191,7 +216,7 @@ def main():
     if args.agent:
         agent(args.agent, args.mode)
     else:
-        for mode in ("success", "failure", "node_timeout"):
+        for mode in ((args.mode,) if args.mode else ("success", "failure", "node_timeout", "nested")):
             run(mode, args.work_dir, args.maa_dir)
 
 


### PR DESCRIPTION
通过 PI 传递 720p/1080p 与最小化设置，sink 报告分辨率变化。连接前只校正窗口，连接后在任务首节点最小化，并保留 ADB 与其他控制器旁路。

## Sourcery 总结

引入受保护且具备平台感知能力的启动准备流程，确保 ADB 和 PC 会话在执行任务前处于就绪状态，同时保留现有的控制器启动路径。

新功能：
- 为 ADB 和 Windows PC 控制器添加启动准备流程，包括前台检测、PC 窗口大小设置、全屏恢复、可选最小化以及启动器交接。
- 支持可配置的 720p 或 1080p PC 启动设置，并将最小化操作延迟到控制器连接和任务启动时执行。

错误修复：
- 防止启动失败后，后续任务仍在代理会话中继续执行。
- 避免启动期间发生不安全的控制器重新绑定、过期的 PC 窗口处理，以及无限等待 shell 或原生窗口。

增强功能：
- 保留特定于平台的启动行为，并绕过其他控制器类型的准备流程，同时保持 Android overlay 兼容性。

构建：
- 将 Android 安装限制为受支持的资源和预任务条目，清理过期的平台资源包，并配置 Windows PC 预任务可执行文件路径。

文档：
- 记录精简后的 Android 资源包以及平台资源清理行为。

测试：
- 新增离线测试和原生契约测试，覆盖启动时序、ADB 前台处理、PC 窗口选项、控制器/任务缓存、安装过滤以及隔离式 bootstrap 导入。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在任务执行前准备 ADB 和 Windows PC 会话，同时保留其他控制器现有的启动行为。

新功能：
- 为 ADB 和 Windows PC 控制器添加启动准备流程，包括前台就绪检查、PC 窗口配置和延迟最小化。
- 支持可配置的 720p 或 1080p PC 启动选项，并保留平台特定的控制器启动行为。

错误修复：
- 当控制器的启动准备失败时，停止执行该控制器后续的任务，并为 shell 命令、窗口和启动器交接设置等待上限。
- 防止启动过程中发生不安全的控制器重新绑定，以及 PC 窗口状态过时或透明的问题。

增强功能：
- 将启动准备限制在受支持的控制器类型中，同时保留 Android 覆盖层以及其他控制器现有的启动路径。

构建：
- 安装过程中筛选平台特定的资源和任务前置条目，配置 Windows PC 引导可执行文件，并从 Android 输出中移除过时且不受支持的资源包。

文档：
- 记录精简版 Android 资源包，以及平台特定资源的清理行为。

测试：
- 添加离线测试、原生契约测试、安装筛选测试、覆盖层测试，以及隔离的引导导入测试，覆盖启动顺序、控制器缓存、PC 窗口选项和平台打包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare ADB and Windows PC sessions before task execution while retaining existing startup behavior for other controllers.

New Features:
- Add startup preparation for ADB and Windows PC controllers, including foreground readiness checks, PC window configuration, and deferred minimization.
- Support configurable 720p or 1080p PC startup options and preserve platform-specific controller startup behavior.

Bug Fixes:
- Stop subsequent tasks for a controller after startup preparation fails and bound waits for shell commands, windows, and launcher handoff.
- Prevent unsafe controller rebinding and stale or transparent PC window states during startup.

Enhancements:
- Keep startup preparation isolated to supported controller types while preserving Android overlay and existing startup paths for other controllers.

Build:
- Filter platform-specific resources and pretask entries during installation, configure the Windows PC bootstrap executable, and remove stale unsupported resource packs from Android outputs.

Documentation:
- Document the reduced Android resource package and cleanup behavior for platform-specific resources.

Tests:
- Add offline, native contract, installation-filter, overlay, and isolated bootstrap import coverage for startup sequencing, controller caching, PC window options, and platform packaging.

</details>

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 PC 客户端启动准备流程，支持自动启动、识别和调整游戏窗口。
  - 新增 PC 窗口分辨率（720p/1080p）及启动最小化选项。
  - 启动阶段增加状态检查、超时处理、取消操作和进度反馈。
  - Android 原生启动支持自动识别并启动目标游戏。

- **体验改进**
  - 统一不同平台的启动流程，减少游戏未启动或窗口状态异常。
  - PC 启动准备失败时会安全停止相关任务并提供错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->