### PR TITLE
impr: 按任务启动时的调试配置控制日志台显示

### DIFF
--- a/agent/main.py
+++ b/agent/main.py
@@ -50,6 +50,7 @@ import action # action子文件夹:agent/action/__init__.py里声明的全部
 import recognition
 from utils.instance_resolver import resolve_instance_id  # 实例身份探测(仅日志)
 from utils.host_watchdog import HostWatchdog, cleanup_socket_file  # 宿主(UI)存活守护
+from utils.log_event_sink import LogEventSink
 import fishing_agent # 钓鱼~
 
 def main():
@@ -105,6 +106,9 @@ def main():
     print(f"Socket ID: {socket_id}")
 
     # 3. 启动服务
+    # 独立于 startup.sink 的同步窗口准备；仅任务开始时刷新日志显示配置。
+    AgentServer._set_api_properties()
+    AgentServer.add_tasker_sink(LogEventSink(project_root / "config" / "maa_option.json"))
     # start_up 返回 bool。失败时若继续走 join()，C++ 侧会打一条
     # "msg_thread is not joinable" 然后立刻返回，进程静默退出 —— 必须在这里拦下。
     if not AgentServer.start_up(socket_id):

--- a/agent/utils/log_event_sink.py
+++ b/agent/utils/log_event_sink.py
@@ -1,0 +1,32 @@
+"""每个任务开始时读取一次 MFAA 调试配置，运行期间不轮询。"""
+
+import json
+from pathlib import Path
+
+from maa.event_sink import NotificationType
+from maa.tasker import TaskerEventSink
+
+from . import mfaalog
+
+
+class LogEventSink(TaskerEventSink):
+    def __init__(self, config_path: Path):
+        self.config_path = config_path
+
+    def on_tasker_task(self, tasker, noti_type, detail):
+        if noti_type != NotificationType.Starting:
+            return
+
+        enabled = False
+        try:
+            config = json.loads(self.config_path.read_text(encoding="utf-8-sig"))
+            if not isinstance(config, dict):
+                raise ValueError("配置必须是 JSON 对象")
+            # save_on_error 默认开启，不作为显示调试日志的条件。
+            enabled = any(config.get(key) is True for key in (
+                "recording", "save_draw", "show_hit_box",
+            ))
+        except (OSError, ValueError) as exc:
+            print(f"[LogConfig] 无法读取调试配置，debug 仅写日志文件：{exc}", flush=True)
+
+        mfaalog.set_debug_ui_enabled(enabled)

--- a/agent/utils/mfaalog.py
+++ b/agent/utils/mfaalog.py
@@ -4,6 +4,15 @@ import time
 # 核心修改：MFA GUI 监听的是标准输出，且需要特定的前缀
 # 开发者原话："focus或者字符串前面拼接info："
 
+_debug_ui_enabled = False
+
+
+def set_debug_ui_enabled(enabled: bool) -> None:
+    """由任务启动事件更新；日志输出本身不读取客户端配置。"""
+    global _debug_ui_enabled
+    _debug_ui_enabled = enabled is True
+
+
 def _print_to_gui(prefix, msg):
     """
     基础输出函数
@@ -36,9 +45,11 @@ def error(msg):
     _print_to_gui("error:", f"🔴 >>> {msg}")
 
 def debug(msg):
-    """调试日志"""
-    # debug 可能会被 GUI 过滤，如果显示不出来，可以改用 info: [DEBUG]
-    _print_to_gui("debug:", msg)
+    """始终保留调试日志；仅调试模式使用 MFAA 日志台识别的前缀。"""
+    if _debug_ui_enabled:
+        _print_to_gui("debug:", msg)
+    else:
+        print(f"[DEBUG] {msg}", flush=True)
 
 def focus(task_id):
     """


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 任务启动时自动读取调试配置，并根据录制、绘制保存或命中框显示设置启用调试界面。
  - 调试信息可同步显示在界面中，便于查看任务运行状态。

- **问题修复**
  - 配置文件读取或解析失败时，任务仍可继续写入日志，并保持调试界面关闭。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->